### PR TITLE
Chore: Add Support for PHP Linting

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,11 +10,11 @@
 /src
 CHANGELOG.md
 CONTRIBUTING.md
-Gruntfile.js
 README.md
 composer.json
 composer.lock
 db
 docker-compose.yml
 package*.json
+phpcs.xml
 webpack.config.js

--- a/.github/workflows/deploy-to-wordpress-org.yml
+++ b/.github/workflows/deploy-to-wordpress-org.yml
@@ -15,6 +15,7 @@ jobs:
     - name: Build the plugin
       run: |
         composer install
+        composer lint
         npm install
         npm run lint
         npm run build

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -27,6 +27,8 @@ jobs:
         npm ci
         composer install
     - name: Lint
-      run: npm run lint
+      run:  |
+        npm run lint
+        composer lint
     - name: Build the application
       run: npm run build --if-present

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,18 @@
 {
   "name"        : "jordanleven/force-refresh",
   "description" : "Force Refresh is a simple plugin that allows you to force a page refresh for users currently visiting your site.",
+  "scripts": {
+    "post-install-cmd": "composer run config-phpcs",
+    "post-update-cmd" : "composer run config-phpcs",
+    "config-phpcs": "phpcs --config-set installed_paths vendor/wp-coding-standards/wpcs",
+    "lint": "phpcs filter-force-refresh.php ./includes"
+  },
   "require": {
+    "php": ">=5.6",
     "zordius/lightncandy": "^1.2.5"
+  },
+  "require-dev": {
+    "squizlabs/php_codesniffer": "^3.5",
+    "wp-coding-standards/wpcs": "^2.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea3d043b5bd948deb41526a674c0ca8c",
+    "content-hash": "ce2835bb97c451a615140b747cabc837",
     "packages": [
         {
             "name": "zordius/lightncandy",
@@ -59,13 +59,113 @@
             "time": "2020-03-08T06:00:24+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-08-10T04:50:15+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.3.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2020-05-13T23:57:56+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "php": ">=5.6"
+    },
     "platform-dev": [],
     "plugin-api-version": "1.1.0"
 }

--- a/filter-force-refresh.php
+++ b/filter-force-refresh.php
@@ -1,6 +1,13 @@
 <?php
+/**
+ * The main init file for the Force Refresh plugin.
+ *
+ * @package ForceRefresh
+ */
 
 namespace JordanLeven\Plugins\ForceRefresh;
+
+// phpcs:disable Generic.Files.LineLength
 
 /*
 Plugin Name: Force Refresh
@@ -12,6 +19,8 @@ Author URI: https://github.com/jordanleven
 Contributors:
 */
 
+// phpcs:disable Generic.Files.LineLength
+
 // Define the name of the action for the refresh. This is used with the nonce to create a unique action
 // when admins request a refresh.
 define( 'WP_FORCE_REFRESH_ACTION', 'wp_force_refresh' );
@@ -20,116 +29,112 @@ define( 'WP_FORCE_REFRESH_ACTION', 'wp_force_refresh' );
 define( 'WP_FORCE_REFRESH_CAPABILITY', 'invoke_force_refresh' );
 // Define the ID for the Handlebars admin notice. This is used to add notifications to the admin screen when a user requests a refresh.
 define( 'WP_FORCE_REFRESH_HANDLEBARS_ADMIN_NOTICE_TEMPLATE_ID', 'invoke_force_refresh' );
-// Define the option for showing the Force Refresh button in the WordPress Admin Bar
+// Define the option for showing the Force Refresh button in the WordPress Admin Bar.
 define( 'WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR', 'force_refresh_show_in_wp_admin_bar' );
-// Define the option for the refresh interval (how often the site should check for a new version)
+// Define the option for the refresh interval (how often the site should check for a new version).
 define( 'WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS', 'force_refresh_refresh_interval' );
-// Define the default refresh interval
+// Define the default refresh interval.
 define( 'WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT', 120 );
-// All the post types to exclude force refreshing from
+// All the post types to exclude force refreshing from.
 define( 'WP_FORCE_REFRESH_EXCLUDE_FROM_POST_TYPES', array( 'attachment' ) );
 
-// Make sure we include the composer autoload file
-require_once __DIR__ . "/vendor/autoload.php";
+// Make sure we include the composer autoload file.
+require_once __DIR__ . '/vendor/autoload.php';
 
-// Include the functions file
-require_once __DIR__ . "/includes/functions.php";
+// Include the functions file.
+require_once __DIR__ . '/includes/functions.php';
 
 /**
  * Function for getting the directory for this plugin
  *
  * @return string The full directory this plugin is located in (including the plugin directory)
- *
- * @version 2.0 Introducted in version 2.0
  */
-function get_force_refresh_plugin_directory(){
-
-    // Declare our plugin directory
-    $plugin_directory = plugin_dir_path(__FILE__);
-
+function get_force_refresh_plugin_directory() {
+    // Declare our plugin directory.
+    $plugin_directory = plugin_dir_path( __FILE__ );
     return $plugin_directory;
 }
 
 /**
  * Function for getting the uri for this plugin
  *
- * @param  string $file The optional file path you want to append to the urldecode(str)
+ * @param  string $file The optional file path you want to append to the urldecode(str).
  *
  * @return string The full url for the root of this plugin is located in (including the plugin directory)
- *
- * @version 2.0 Introducted in version 2.0
  */
-function get_force_refresh_plugin_url($file = null){
-
-    // Declare our plugin directory
-    $plugin_url = plugins_url($file, __FILE__);
-
+function get_force_refresh_plugin_url( $file = null ) {
+    // Declare our plugin directory.
+    $plugin_url = plugins_url( $file, __FILE__ );
     return $plugin_url;
 }
 
-// Add the menu where we'll configure the settings
-add_action( 'admin_menu', function(){
+// Add the menu where we'll configure the settings.
+add_action(
+    'admin_menu',
+    function() {
+        add_submenu_page(
+            'tools.php',
+            'Force Refresh',
+            'Force Refresh',
+            WP_FORCE_REFRESH_CAPABILITY,
+            'force_refresh',
+            __NAMESPACE__ . '\\manage_force_refresh'
+        );
+    }
+);
 
-    add_submenu_page(
-        'tools.php',
-        'Force Refresh',
-        'Force Refresh',
-        WP_FORCE_REFRESH_CAPABILITY,
-        'force_refresh',
-        __NAMESPACE__ . '\\manage_force_refresh'
-    );
+// Add the action to add the Force Refresh capability to allow developers to customize which users and roles can init a Force Refresh.
+add_action(
+    'admin_init',
+    function() {
+        $role = get_role( 'administrator' );
+        $role->add_cap( WP_FORCE_REFRESH_CAPABILITY );
+    }
+);
 
-});
+// Add the script for normal front-facing pages (non-admin).
+add_action(
+    'wp_enqueue_scripts',
+    function() {
+        // Include the normal JS.
+        add_script( 'force-refresh-js', '/dist/js/force-refresh.js', true );
+        // Localize the admin ajax URL. This doesn't sound like the best idea but WP is into it (https://codex.wordpress.org/AJAX_in_Plugins).
+        wp_localize_script(
+            'force-refresh-js',
+            'force_refresh_js_object',
+            array(
+                // Get the ajax URL.
+                'ajax_url'         => admin_url( 'admin-ajax.php' ),
+                // Get the post ID.
+                'post_id'          => get_the_ID(),
+                // Get the refresh interval.
+                'refresh_interval' => get_option(
+                    WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS,
+                    WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT,
+                ),
+            )
+        );
+        // Now that it's registered, enqueue the script.
+        wp_enqueue_script( 'force-refresh-js' );
+    }
+);
 
-// Add the action to add the Force Refresh capability to allow developers to customize which users and roles
-// can init a Force Refresh
-add_action("admin_init", function(){
-
-  $role = get_role("administrator");
-
-  $role->add_cap(WP_FORCE_REFRESH_CAPABILITY);
-
-});
-
-// Add the script for normal frontfacing pages (non-admin)
-add_action("wp_enqueue_scripts", function(){
-
-    // Include the normal JS
-    add_script("force-refresh-js", "/dist/js/force-refresh.js", true);
-
-    // Localize the admin ajax URL. This doesn't sound like the best idea but WP is into it (https://codex.wordpress.org/AJAX_in_Plugins)
-    wp_localize_script(
-        "force-refresh-js",
-        "force_refresh_js_object",
-        array(
-            // Get the ajax URL
-            'ajax_url'         => admin_url( 'admin-ajax.php' ),
-            // Get the post ID
-            'post_id'          => get_the_ID(),
-            // Get the refresh interval
-            'refresh_interval' => get_option( WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT )
-        )
-    );
-
-    // Now that it's registered, enqueue the script
-    wp_enqueue_script("force-refresh-js");
-
-});
-
-// Add meta boxes for specific pages that we want to refresh
-add_action('add_meta_boxes',  function(){
-    // All post types
-    $all_post_types = get_post_types();
-    // Loop through all the post types
-    foreach ($all_post_types as $post_type => $post_key) {
-        // Get the post type attributes
+// Add meta boxes for specific pages that we want to refresh.
+add_action(
+    'add_meta_boxes',
+    function() {
+        // All post types.
+        $all_post_types = get_post_types();
+        // Loop through all the post types.
+      foreach ( $all_post_types as $post_type => $post_key ) {
+        // Get the post type attributes.
         $post_type_attributes = get_post_type_object( $post_type );
-        // The post types public attribute
+        // The post types public attribute.
         $post_type_is_public = $post_type_attributes->public;
         // Only add the box if the post type is public and we're not excluding
-        // the post type
-        if ( $post_type_is_public && !in_array($post_type, WP_FORCE_REFRESH_EXCLUDE_FROM_POST_TYPES )){
-            // Add the box
+        // the post type.
+        if ( $post_type_is_public && ! in_array( $post_type, WP_FORCE_REFRESH_EXCLUDE_FROM_POST_TYPES, true ) ) {
+            // Add the box.
             add_meta_box(
                 'force_refresh_specific_page_refresh',
                 'Force Refresh',
@@ -138,7 +143,6 @@ add_action('add_meta_boxes',  function(){
                 'side'
             );
         }
+      }
     }
-});
-
-?>
+);

--- a/includes/ajax-calls-admin.php
+++ b/includes/ajax-calls-admin.php
@@ -1,121 +1,144 @@
 <?php
+/**
+ * Our API calls responsible for handling requests from admins requesting a refresh for the site.
+ *
+ * @package ForceRefresh
+ */
 
-// The call used for admins requesting a site be refreshed
-add_action( 'wp_ajax_force_refresh_update_site_version', function() {
-    // Get the data
-    $data         = $_REQUEST;
-    // Declare our return
-    $return_array = array();
-    // Get the nonce
-    $nonce        = $data['nonce'];
-    // Whether or not the call was successful
-    $success      = false;
-    // The HTTP status code
-    $status_code  = null;
-    // The status text
-    $status_text  = null;
-    // The return data
-    $return_data  = array();
-    // Check the nonce
-    if (wp_verify_nonce( $nonce, WP_FORCE_REFRESH_ACTION )){
-        // If the user is authenticated, get the current site version by making a hash of the current date
-        $time = current_time( 'timestamp' );
-        // Create the site version
-        $site_version_hash = wp_hash( $time );
-        // Get the first eight characters (the chance of having a duplicate hash from the first 8 characters is low)
-        $site_version = substr( $site_version_hash, 0, 8 );
-        // Remove the old option
-        delete_option( 'force_refresh_current_site_version' );
-        // Add the new option
-        add_option('force_refresh_current_site_version', $site_version, null, 'no' );
-        // The call was successful
-        $success = true;
-        // Redeclare the status code as 200
-        $status_code = 200;
-        // Redeclare the status text
-        $status_text = 'You\'ve successfully requested all browsers to refresh (version <code>'. $site_version .'</code>).';
-        // Redeclare the status text
-        $return_data['new_site_version'] = $site_version;
-    }
-    else {
-        // Redeclare the status code as 401 (unauthorized)
-        $status_code = 401;
-        $status_text = 'There was an issue verifying your nonce ($nonce).';
-    }
-    // Set the HTTP code
-    status_header($status_code);
-    // Return the success
-    $return_array['success']     = $success;
-    // Return the status code
-    $return_array['status_code'] = $status_code;
-    // Return the status text
-    $return_array['status_text'] = $status_text;
-    // Return the return data
-    $return_array['return_data'] = $return_data;
-    print json_encode($return_array);
-    wp_die();
-});
+namespace JordanLeven\Plugins\ForceRefresh;
 
-// The call used for admins requesting a site be refreshed
-add_action( 'wp_ajax_force_refresh_update_page_version', function(){
-    // Get the data
-    $data         = $_REQUEST;
-    // Declare our return
-    $return_array = array();
-    // Get the nonce
-    $nonce        = $data['nonce'];
-    // Get the page id
-    $page_id      = $data['page_id'];
-    // Whether or not the call was successful
-    $success      = false;
-    // The HTTP status code
-    $status_code  = null;
-    // The status text
-    $status_text  = null;
-    // The return data
-    $return_data = array();
-    // Check the nonce
-    if (wp_verify_nonce($nonce, WP_FORCE_REFRESH_ACTION)){
-        // If the user is authenticated, get the current site version by making a hash of the current date
-        $time = current_time('timestamp');
-        // Get the hash
-        $page_version_hash = wp_hash($time);
-        // Get the first eight characters (the chance of having a duplicate hash from the first 8 characters is low)
-        $page_version = substr($page_version_hash, 0, 8);
-        // Remove the old
+// The call used for admins requesting a site be refreshed.
+add_action(
+    'wp_ajax_force_refresh_update_site_version',
+    function () {
+      $nonce = isset( $_REQUEST['nonce'] )
+        ? sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) )
+        : null;
+      // Declare our return.
+      $return_array = array();
+      // Whether or not the call was successful.
+      $success = false;
+      // The HTTP status code.
+      $status_code = null;
+      // The status text.
+      $status_text = null;
+      // The return data.
+      $return_data = array();
+      // Check the nonce.
+      if ( wp_verify_nonce( $nonce, WP_FORCE_REFRESH_ACTION ) ) {
+        // Get the data.
+        $data = $_REQUEST;
+          // If the user is authenticated, get the current site version by
+          // making a hash of the current date.
+          $time = current_time( 'mysql' );
+          // Create the site version.
+          $site_version_hash = wp_hash( $time );
+          // Get the first eight characters (the chance of having a duplicate hash from
+          // the first 8 characters is low).
+          $site_version = substr( $site_version_hash, 0, 8 );
+          // Remove the old option.
+          delete_option( 'force_refresh_current_site_version' );
+          // Add the new option.
+          add_option( 'force_refresh_current_site_version', $site_version, '', 'no' );
+          // The call was successful.
+          $success = true;
+          // Redeclare the status code as 200.
+          $status_code = 200;
+          // Redeclare the status text.
+          $status_text = "You've successfully requested all browsers to refresh
+            (version <code>$site_version</code>).";
+          // Redeclare the status text.
+          $return_data['new_site_version'] = $site_version;
+      } else {
+          // Redeclare the status code as 401 (unauthorized).
+          $status_code = 401;
+          $status_text = 'There was an issue verifying your nonce ($nonce).';
+      }
+      // Set the HTTP code.
+      status_header( $status_code );
+      // Return the success.
+      $return_array['success'] = $success;
+      // Return the status code.
+      $return_array['status_code'] = $status_code;
+      // Return the status text.
+      $return_array['status_text'] = $status_text;
+      // Return the return data.
+      $return_array['return_data'] = $return_data;
+      print wp_json_encode( $return_array );
+      wp_die();
+    }
+);
+
+// The call used for admins requesting a site be refreshed.
+add_action(
+    'wp_ajax_force_refresh_update_page_version',
+    function () {
+      $nonce = isset( $_REQUEST['nonce'] )
+      ? sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) )
+      : null;
+      // Declare our return.
+      $return_array = array();
+      // Whether or not the call was successful.
+      $success = false;
+      // The HTTP status code.
+      $status_code = null;
+      // The status text.
+      $status_text = null;
+      // The return data.
+      $return_data = array();
+      // Check the nonce.
+      if ( wp_verify_nonce( $nonce, WP_FORCE_REFRESH_ACTION ) ) {
+        // Get the data.
+        $data = $_REQUEST;
+        // Get the page id.
+        $page_id = $data['page_id'];
+        // If the user is authenticated, get the current site version by
+        // making a hash of the current date.
+        $time = current_time( 'mysql' );
+        // Get the hash.
+        $page_version_hash = wp_hash( $time );
+        // Get the first eight characters (the chance of having a duplicate hash
+        // from the first 8 characters is low).
+        $page_version = substr( $page_version_hash, 0, 8 );
+        // Remove the old.
         delete_post_meta( $page_id, 'force_refresh_current_page_version' );
-        // Add the new
-        update_post_meta( $page_id, 'force_refresh_current_page_version', $page_version, null, 'no' );
-        // The call was successful
+        // Add the new.
+        update_post_meta(
+            $page_id,
+            'force_refresh_current_page_version',
+            $page_version,
+            null,
+            'no',
+        );
+        // The call was successful.
         $success = true;
-        // Redeclare the status code as 200
+        // Redeclare the status code as 200.
         $status_code = 200;
-        // Redeclare the status text
-        $status_text = 'You\'ve successfully requested all browsers to refresh this page (version <code>' . $page_version . '</code>).';
-        // Redeclare the status text
+        // Redeclare the status text.
+        $status_text = 'You\'ve successfully requested all browsers to refresh this page
+          (version <code>' . $page_version . '</code>).';
+        // Redeclare the status text.
         $return_data['new_page_version'] = $page_version;
-        $return_data['refresh_interval'] = (int) get_option(WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT);
-
+        $return_data['refresh_interval'] = (int) get_option(
+            WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS,
+            WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT
+        );
+      } else {
+          // Redeclare the status code as 401 (unauthorized).
+          $status_code = 401;
+          $status_text = 'There was an issue verifying your nonce ($nonce).';
+      }
+      // Set the HTTP code.
+      status_header( $status_code );
+      // Return the success.
+      $return_array['success'] = $success;
+      // Return the status code.
+      $return_array['status_code'] = $status_code;
+      // Return the status text.
+      $return_array['status_text'] = $status_text;
+      // Return the return data.
+      $return_array['return_data'] = $return_data;
+      print wp_json_encode( $return_array );
+      wp_die();
     }
-    else {
-        // Redeclare the status code as 401 (unauthorized)
-        $status_code = 401;
-        $status_text = 'There was an issue verifying your nonce ($nonce).';
-    }
-    // Set the HTTP code
-    status_header($status_code);
-    // Return the success
-    $return_array['success']     = $success;
-    // Return the status code
-    $return_array['status_code'] = $status_code;
-    // Return the status text
-    $return_array['status_text'] = $status_text;
-    // Return the return data
-    $return_array['return_data'] = $return_data;
-    print json_encode($return_array);
-    wp_die();
-});
-
-
-
-?>
+);

--- a/includes/ajax-calls-client.php
+++ b/includes/ajax-calls-client.php
@@ -1,58 +1,68 @@
 <?php
+/**
+ * Our API calls responsible for handling requests from website visitors.
+ *
+ * @package ForceRefresh
+ */
 
-// The call used for users requesting the current site version from non-admins
-add_action( 'wp_ajax_nopriv_force_refresh_get_version', __NAMESPACE__ . "\\ajax_request_get_version");
+// phpcs:disable WordPress.Security.NonceVerification
 
-// The call used for users requesting the current site version from admins
-add_action( 'wp_ajax_force_refresh_get_version', __NAMESPACE__ . "\\ajax_request_get_version");
+// The call used for users requesting the current site version from non-admins.
+add_action(
+    'wp_ajax_nopriv_force_refresh_get_version',
+    __NAMESPACE__ . '\\ajax_request_get_version'
+);
+
+// The call used for users requesting the current site version from admins.
+add_action(
+    'wp_ajax_force_refresh_get_version',
+    __NAMESPACE__ . '\\ajax_request_get_version'
+);
 
 /**
- * The function used by ajax requests to get the current site version.
+ * Function used by ajax requests to get the current site version.
  *
- * @return    void
- *
- * @version 1.0 Introducted in version 1.0
+ * @return void
  */
-function ajax_request_get_version(){
-    // Get the data
-    $data = $_REQUEST;
-    // Declare our return
-    $return_array = array();
-    // Whether or not the call was successful
-    $success      = true;
-    // The HTTP status code
-    $status_code  = 200;
-    // The status text
-    $status_text  = "The current site version has been successfully retrieved.";
-    // Get the post ID
-    $post_id      = isset( $_REQUEST['post_id'] ) ? $_REQUEST['post_id'] : null;
-    // The return data
-    $return_data  = array();
-    // Get the current site version
-    $current_site_version = get_option("force_refresh_current_site_version");
-    // Get the current site version
-    $current_page_version = get_post_meta( $post_id, 'force_refresh_current_page_version', true);
-    // If no current site version exists, then the site version will default to version 0. This should be a string and not an integer
-    if ( !$current_site_version ){
-        $current_site_version = "0";
-    }
-    if ( !$current_page_version ){
-        $current_page_version = "0";
-    }
-    $return_data['current_site_version'] = $current_site_version;
-    $return_data['current_page_version'] = $current_page_version;
-    // Set the HTTP code
-    status_header($status_code);
-    // Return the success
-    $return_array['success']     = $success;
-    // Return the status code
-    $return_array['status_code'] = $status_code;
-    // Return the status text
-    $return_array['status_text'] = $status_text;
-    // Return the return data
-    $return_array['return_data'] = $return_data;
-    print json_encode($return_array);
-    wp_die();
+function ajax_request_get_version() {
+  // Declare our return.
+  $return_array = array();
+  // Whether or not the call was successful.
+  $success = true;
+  // The HTTP status code.
+  $status_code = 200;
+  // The status text.
+  $status_text = 'The current site version has been successfully retrieved.';
+  // Get the post ID.
+  $post_id = isset( $_REQUEST['post_id'] )
+    ? sanitize_text_field( wp_unslash( $_REQUEST['post_id'] ) )
+    : null;
+  // The return data.
+  $return_data = array();
+  // Get the current site version.
+  $current_site_version = get_option( 'force_refresh_current_site_version' );
+  // Get the current site version.
+  $current_page_version = get_post_meta( $post_id, 'force_refresh_current_page_version', true );
+  // If no current site version exists, then the site version will default to version 0.
+  // This should be a string and not an integer.
+  if ( ! $current_site_version ) {
+      $current_site_version = '0';
+  }
+  if ( ! $current_page_version ) {
+      $current_page_version = '0';
+  }
+  $return_data['current_site_version'] = $current_site_version;
+  $return_data['current_page_version'] = $current_page_version;
+  // Set the HTTP code.
+  status_header( $status_code );
+  // Return the success.
+  $return_array['success'] = $success;
+  // Return the status code.
+  $return_array['status_code'] = $status_code;
+  // Return the status text.
+  $return_array['status_text'] = $status_text;
+  // Return the return data.
+  $return_array['return_data'] = $return_data;
+  print wp_json_encode( $return_array );
+  wp_die();
 }
-
-?>

--- a/includes/function-handlebars.php
+++ b/includes/function-handlebars.php
@@ -1,94 +1,92 @@
 <?php
+/**
+ * Functions relating to our use of handlebars.
+ *
+ * @package ForceRefresh
+ */
 
 namespace JordanLeven\Plugins\ForceRefresh;
 
 use LightnCandy as ZordiusLightnCandy;
 
-// The location of the handlebars directory relative to the plugin root
-define("FORCE_REFRESH_HANDLEBARS_DIRECTORY", "/dist/handlebars/");
+// The location of the handlebars directory relative to the plugin root.
+define( 'FORCE_REFRESH_HANDLEBARS_DIRECTORY', '/dist/handlebars/' );
 
 /**
  * Function used to add a handlebars template to the DOM (to be used by JavaScript).
  *
- * @param    string     $id                The ID used to identify the handlebars  template
- * @param    string     $src               The location of the handlebars template relative to the predefined handlebars template directory
+ * @param string $id  The ID used to identify the handlebars  template.
+ * @param string $src The location of the handlebars template relative to the
+ *                    predefined handlebars template directory.
  */
-function add_handlebars($id, $src){
-    // Get the directory of the plugin
+function add_handlebars( $id, $src ) {
+    // Get the directory of the plugin.
     $directory = get_force_refresh_plugin_directory();
-
-    // Get the location of the Handlebars template
+    // Get the location of the Handlebars template.
     $file_location = $directory . FORCE_REFRESH_HANDLEBARS_DIRECTORY . $src;
-
-    if (file_exists($file_location)){
-
-        $handlebar_contents = file_get_contents($file_location);
-
-        echo '<script id="' . $id . '" type="text/x-handlebars-template">';
-        echo $handlebar_contents;
-        echo '</script>';
-    }
-
-    else {
-        error_log("Handlebars template ($file_location) doesn't exist");
-    }
+  if ( file_exists( $file_location ) ) {
+      // phpcs:disable WordPress.WP.AlternativeFunctions
+      // In the future, this method of loading handlebars templates will be deprecated as the
+      // front-end moves towards Vue.
+      $handlebar_contents = file_get_contents( $file_location );
+      // phpcs:enable WordPress.WP.AlternativeFunctions
+      echo '<script id="' . esc_html( $id ) . '" type="text/x-handlebars-template">';
+      // phpcs:disable WordPress.Security.EscapeOutput
+      // In the future, this method of loading handlebars templates will be deprecated as the
+      // front-end moves towards Vue.
+      echo $handlebar_contents;
+      // phpcs:enable WordPress.Security.EscapeOutput
+      echo '</script>';
+  }
 }
 
 /**
-* Function to render handlebars in PHP. Users the Handlebars framework (via Composer).
-*
-* @param     string     $template_name         The name of the template
-* @param     array      $replacements_array    The replacements
-* @param     boolean    $return                Whether to return the HTML or print it
-*
-* @return    string The HTML
-*/
-function render_handlebars($template_name, $replacements_array = array(), $return = false){
-
-    // Get the directory of the plugin
+ * Function to render handlebars in PHP. Users the Handlebars framework (via Composer).
+ *
+ * @param string  $template_name           The name of the template.
+ * @param array   $replacements_array  The replacements.
+ * @param boolean $return                 Whether to return the HTML or print it.
+ *
+ * @return string The HTML
+ */
+function render_handlebars(
+  $template_name,
+  $replacements_array = array(),
+  $return = false
+  ) {
+    // Get the directory of the plugin.
     $directory = get_force_refresh_plugin_directory();
-
-    // Add the template directory to the replacements
-    $replacements_array["template_directory_uri"] = get_template_directory_uri();
-
-    $file_location = $directory . FORCE_REFRESH_HANDLEBARS_DIRECTORY . $template_name;
-
-    $file_directory = dirname($file_location);
-
-    if (file_exists($file_location)){
-
-        // Get the file contents
-        $handlebar_contents = file_get_contents($file_location);
-
-        $php = ZordiusLightnCandy\LightnCandy::compile(
-            $handlebar_contents, array(
-                'flags' => ZordiusLightnCandy\LightnCandy::FLAG_RENDER_DEBUG | ZordiusLightnCandy\LightnCandy::FLAG_HANDLEBARSJS
-            )
-        );
-
-        // Get the render function
-        $renderer = ZordiusLightnCandy\LightnCandy::prepare($php);
-
-        $rendered_html = $renderer($replacements_array);
-
-        // If return is true, then return the HTML
-        if ($return){
-
-            return $rendered_html;
-        }
-
-        // Otherwise, echo it
-        else {
-
-            echo $rendered_html;
-
-        }
-
+    // Add the template directory to the replacements.
+    $replacements_array['template_directory_uri'] = get_template_directory_uri();
+    $file_location                                = $directory
+                                                    . FORCE_REFRESH_HANDLEBARS_DIRECTORY
+                                                    . $template_name;
+  if ( file_exists( $file_location ) ) {
+      // Get the file contents.
+      // phpcs:disable WordPress.WP.AlternativeFunctions
+      // In the future, this method of loading handlebars templates will be deprecated as the
+      // front-end moves towards Vue.
+    $handlebar_contents = file_get_contents( $file_location );
+      // phpcs:enable WordPress.WP.AlternativeFunctions
+    $php = ZordiusLightnCandy\LightnCandy::compile(
+        $handlebar_contents,
+        array(
+            'flags' => ZordiusLightnCandy\LightnCandy::FLAG_RENDER_DEBUG
+              | ZordiusLightnCandy\LightnCandy::FLAG_HANDLEBARSJS,
+        ),
+    );
+    // Get the render function.
+    $renderer      = ZordiusLightnCandy\LightnCandy::prepare( $php );
+    $rendered_html = $renderer( $replacements_array );
+    // If return is true, then return the HTML.
+    if ( $return ) {
+      return $rendered_html;
     }
-
-    else {
-        error_log("Unable to locate handlebars: " . $file_location);
-    }
+    // Otherwise, echo it.
+    // phpcs:disable WordPress.Security.EscapeOutput
+    // In the future, this method of loading handlebars templates will be deprecated as the
+    // front-end moves towards Vue.
+    echo $rendered_html;
+    // phpcs:disable WordPress.Security.EscapeOutput
+  }
 }
-
-?>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,142 +1,187 @@
 <?php
+/**
+ * All of our utility functions that are used throughout the plugin.
+ *
+ * @package ForceRefresh
+ */
+
+// phpcs:disable WordPress.Security.NonceVerification
 
 namespace JordanLeven\Plugins\ForceRefresh;
 
-// Include the handlebars function
-require_once __DIR__ . "/function-handlebars.php";
+// Include the handlebars function.
+require_once __DIR__ . '/function-handlebars.php';
+// All ajax calls from browsers.
+require_once __DIR__ . '/ajax-calls-client.php';
+// All ajax calls from admins.
+require_once __DIR__ . '/ajax-calls-admin.php';
 
-// All ajax calls from browsers
-require_once __DIR__ . "/ajax-calls-client.php";
-
-// All ajax calls from admins
-require_once __DIR__ . "/ajax-calls-admin.php";
-
+/**
+ * Main function to generate the admin HTML.
+ *
+ * @return  void
+ */
 function force_refresh_specific_page_refresh_html() {
-  define('HTML_CLASS_META_BOX', 'force-refresh-meta-box');
-  define('FILE_NAME_META_BOX_ADMIN', 'force-refresh-meta-box-admin-js');
-  // Include the admin JS
-  add_script( FILE_NAME_META_BOX_ADMIN, '/dist/js/force-refresh-meta-box-admin.js', true );
-  // Get the current screen
-  $current_screen = get_current_screen();
-  // Create the data we're going to localize to the script
-  $localized_data = array(
-    // Wrap in inner array to preserve primitive types
-    'localData' => array(
-      // Add the API URL for the script
-      'apiUrl' => get_stylesheet_directory_uri(),
-      // Add the API URL for the script
-      'siteId' => get_current_blog_id(),
-      // Create a nonce for the user
-      'nonce' => wp_create_nonce(WP_FORCE_REFRESH_ACTION),
-      // Create a nonce for the user
-      'postId' => get_the_ID(),
-      'postType' => $current_screen->post_type,
-      'postName' => get_the_title(),
-      'targetClass' => HTML_CLASS_META_BOX,
-      // Add the refresh interval
-      'refreshInterval' => get_option(WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT),
-    )
-  );
-  // Localize the data
-  wp_localize_script(
-    FILE_NAME_META_BOX_ADMIN,
-    "forceRefreshLocalJs",
-    $localized_data
-  );
-  // Now that it's registered, enqueue the script
-  wp_enqueue_script(FILE_NAME_META_BOX_ADMIN);
-  echo "<div class=\"" . HTML_CLASS_META_BOX . "\"></div>";
+    define( 'HTML_CLASS_META_BOX', 'force-refresh-meta-box' );
+    define( 'FILE_NAME_META_BOX_ADMIN', 'force-refresh-meta-box-admin-js' );
+    // Include the admin JS.
+    add_script( FILE_NAME_META_BOX_ADMIN, '/dist/js/force-refresh-meta-box-admin.js', true );
+    // Get the current screen.
+    $current_screen = get_current_screen();
+    // Create the data we're going to localize to the script.
+    $localized_data = array(
+        // Wrap in inner array to preserve primitive types.
+        'localData' => array(
+            // Add the API URL for the script.
+            'apiUrl'          => get_stylesheet_directory_uri(),
+            // Add the API URL for the script.
+            'siteId'          => get_current_blog_id(),
+            // Create a nonce for the user.
+            'nonce'           => wp_create_nonce( WP_FORCE_REFRESH_ACTION ),
+            // Create a nonce for the user.
+            'postId'          => get_the_ID(),
+            'postType'        => $current_screen->post_type,
+            'postName'        => get_the_title(),
+            'targetClass'     => HTML_CLASS_META_BOX,
+            // Add the refresh interval.
+            'refreshInterval' => get_option(
+                WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS,
+                WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT
+            ),
+        ),
+    );
+    // Localize the data.
+    wp_localize_script( FILE_NAME_META_BOX_ADMIN, 'forceRefreshLocalJs', $localized_data );
+    // Now that it's registered, enqueue the script.
+    wp_enqueue_script( FILE_NAME_META_BOX_ADMIN );
+    echo '<div class="' . esc_html( HTML_CLASS_META_BOX ) . '"></div>';
 }
 
 /**
- * Hook used to enqueue CSS and JS, as well as add the optional Force Refresh button to the WordPress Admin Bar.
+ * Hook used to enqueue CSS and JS, as well as add the optional Force Refresh button to the
+ * WordPress Admin Bar.
+ *
+ * @return void
  */
-add_action('admin_head', function(){
-    // Get this option from the database. Default value is null/false
-    $show_force_refresh_in_wp_admin_bar = get_option(WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR) === 'true';
-    // If the option to show Force Refresh in the admin bar is enabled, then we need to show the item in the WordPress Admin Bar
-    if ( $show_force_refresh_in_wp_admin_bar ){
-        // Show the Force Refresh option in the WordPress Admin Bar
-        add_action( 'wp_before_admin_bar_render', __NAMESPACE__ . '\\show_force_refresh_in_wp_admin_bar', 999 );
+add_action(
+    'admin_head',
+    function () {
+      // Get this option from the database. Default value is null/false.
+        $show_force_refresh_in_wp_admin_bar = get_option(
+            WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR
+        ) === 'true';
+        // If the option to show Force Refresh in the admin bar is enabled, then we need to show the
+        // item in the WordPress Admin Bar.
+      if ( $show_force_refresh_in_wp_admin_bar ) {
+          // Show the Force Refresh option in the WordPress Admin Bar.
+        add_action(
+            'wp_before_admin_bar_render',
+            __NAMESPACE__ . '\\show_force_refresh_in_wp_admin_bar',
+            999
+        );
+      }
+        // Since a Force Refresh can take place from any page, we also need to add the Handlebars
+        // template for a notice.
+        add_handlebars(
+            WP_FORCE_REFRESH_HANDLEBARS_ADMIN_NOTICE_TEMPLATE_ID,
+            'force-refresh-main-admin-notice.handlebars'
+        );
+        // Include the admin CSS.
+        add_style( 'force-refresh-admin-css', '/dist/css/force-refresh-admin.css' );
+        // Add the Force Refresh script.
+        add_force_refresh_script();
     }
-    // Since a Force Refresh can take place from any page, we also need to add the Handlebars template for a notice
-    add_handlebars( WP_FORCE_REFRESH_HANDLEBARS_ADMIN_NOTICE_TEMPLATE_ID, 'force-refresh-main-admin-notice.handlebars' );
-    // Include the admin CSS
-    add_style("force-refresh-admin-css", "/dist/css/force-refresh-admin.css");
-    // Add the Force Refresh script
-    add_force_refresh_script();
-
-});
+);
 
 /**
  * Hook used to save admin actions for Force Refresh.
  */
-add_action('admin_init', function(){
-    // If we are saving data from the Force Refresh options
-    if (isset($_POST['force-refresh-admin-options-save']) && $_POST['force-refresh-admin-options-save'] == true){
-        // Get updated options for viewing the refresh button in the WP Admin bar
-        $show_in_admin_bar = isset($_POST['show-in-wp-admin-bar']) ? $_POST['show-in-wp-admin-bar'] : false;
-        // Update the show in Admin Bar option
-        update_option(WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR, $show_in_admin_bar);
-        // Get updated options for the refresh interval
-        $refresh_interval = isset($_POST['refresh-interval']) ? $_POST['refresh-interval'] : null;
-        // If the new refresh interval option came through all right
-        if ($refresh_interval){
-            // Update the refresh interval
-            update_option(WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, $refresh_interval);
+add_action(
+    'admin_init',
+    function () {
+      // If we are saving data from the Force Refresh options.
+      if (
+          isset( $_POST['force-refresh-admin-options-save'] ) &&
+          'true' === $_POST['force-refresh-admin-options-save']
+        ) {
+        // Get updated options for viewing the refresh button in the WP Admin bar.
+        $show_in_admin_bar = isset( $_POST['show-in-wp-admin-bar'] )
+        ? sanitize_text_field(
+            wp_unslash( $_POST['show-in-wp-admin-bar'] )
+        ) : false;
+          // Update the show in Admin Bar option.
+          update_option( WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR, $show_in_admin_bar );
+          // Get updated options for the refresh interval.
+          $refresh_interval = isset( $_POST['refresh-interval'] )
+            ? sanitize_text_field( wp_unslash( $_POST['refresh-interval'] ) ) : null;
+          // If the new refresh interval option came through all right.
+        if ( $refresh_interval ) {
+            // Update the refresh interval.
+            update_option( WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, $refresh_interval );
         }
+      }
     }
-});
+);
 
 /**
  * Function to show the Force Refresh option in the WP Admin bar.
  *
  * @return void
- *
- * @version 1.0 Added in version 2.0
  */
-function show_force_refresh_in_wp_admin_bar(){
-    // Globalize the WP Admin Bar object
+function show_force_refresh_in_wp_admin_bar() {
+    // Globalize the WP Admin Bar object.
     global $wp_admin_bar;
-    // Add the item to show up in the WP Admin Bar
+    // Add the item to show up in the WP Admin Bar.
     $args = array(
-        'id'     => 'force-refresh',
-        'title'  => "<i class=\"fa fa-refresh\" aria-hidden=\"true\"></i> <span>Force Refresh Site</span>",
-        'href'   => null,
+        'id'    => 'force-refresh',
+        'title' =>
+          '<i class="fa fa-refresh" aria-hidden="true"></i> <span>Force Refresh Site</span>',
+        'href'  => null,
     );
-    // Add the menu
+    // Add the menu.
     $wp_admin_bar->add_menu( $args );
 }
 
 /**
  * Main function to manage settings for Force Refresh.
  *
- * @return    void
- *
- * @version 1.0 Introducted in version 1.0
+ * @return void
  */
-function manage_force_refresh(){
-    // See what the existing settings are for showing Force Refresh in the WordPress Admin bar
-    $preset_option_show_force_refresh_in_wp_admin_bar = get_option(WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR, false);
-    // See what the existing settings are for the refresh interval
-    $preset_option_refresh_interval = get_option(WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT);
-    // Add the script
+function manage_force_refresh() {
+    // See what the existing settings are for showing Force Refresh in the WordPress Admin bar.
+    $preset_option_show_force_refresh_in_wp_admin_bar = get_option(
+        WP_FORCE_REFRESH_OPTION_SHOW_IN_WP_ADMIN_BAR,
+        false,
+    );
+    // See what the existing settings are for the refresh interval.
+    $preset_option_refresh_interval = get_option(
+        WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS,
+        WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT
+    );
+    // Add the script.
     add_force_refresh_script();
-    // Render the HTML
-    render_handlebars("force-refresh-main-admin.handlebars",
+    // Render the HTML.
+    render_handlebars(
+        'force-refresh-main-admin.handlebars',
         array(
-            "site_name" => get_bloginfo(),
-            "options" => array(
-                // For the Show Force Refresh in Admin Menu option
-                "preset_value_force_refresh_in_admin_bar_show" => $preset_option_show_force_refresh_in_wp_admin_bar === 'true' ? "selected" : null,
-                "preset_value_force_refresh_in_admin_bar_hide" => $preset_option_show_force_refresh_in_wp_admin_bar === 'false' ? "selected" : null,
+            'site_name' => get_bloginfo(),
+            'options'   => array(
+                // For the Show Force Refresh in Admin Menu option.
+                'preset_value_force_refresh_in_admin_bar_show' =>
+                  'true' === $preset_option_show_force_refresh_in_wp_admin_bar ? 'selected' : null,
+                'preset_value_force_refresh_in_admin_bar_hide' =>
+                  'false' === $preset_option_show_force_refresh_in_wp_admin_bar ? 'selected' : null,
 
-                // For the refresh interval option
-                "preset_value_force_refresh_refresh_interval_30"  => $preset_option_refresh_interval === '30' ? "selected" : null,
-                "preset_value_force_refresh_refresh_interval_60"  => $preset_option_refresh_interval === '60' ? "selected" : null,
-                "preset_value_force_refresh_refresh_interval_90"  => $preset_option_refresh_interval === '90' ? "selected" : null,
-                "preset_value_force_refresh_refresh_interval_120" => $preset_option_refresh_interval === '120' ? "selected" : null
-            )
+                // For the refresh interval option.
+                'preset_value_force_refresh_refresh_interval_30' =>
+                  '30' === $preset_option_refresh_interval ? 'selected' : null,
+                'preset_value_force_refresh_refresh_interval_60' =>
+                  '60' === $preset_option_refresh_interval ? 'selected' : null,
+                'preset_value_force_refresh_refresh_interval_90' =>
+                  '90' === $preset_option_refresh_interval ? 'selected' : null,
+                'preset_value_force_refresh_refresh_interval_120' =>
+                  '120' === $preset_option_refresh_interval ? 'selected' : null,
+            ),
         )
     );
 }
@@ -144,124 +189,95 @@ function manage_force_refresh(){
 /**
  * Function to add the Force Refresh script, which contains the nonce required to initiate the call.
  *
- * @version 1.0 Introducted in version 2.0
+ * @return void
  */
-function add_force_refresh_script(){
-
-    // Include the admin JS
-    add_script("force-refresh-main-admin-js", "/dist/js/force-refresh-main-admin.js", true);
-
-    // Create the data we're going to localize to the script
+function add_force_refresh_script() {
+    // Include the admin JS.
+    add_script( 'force-refresh-main-admin-js', '/dist/js/force-refresh-main-admin.js', true );
+    // Create the data we're going to localize to the script.
     $localized_data = array();
-
-    // Add the API URL for the script
+    // Add the API URL for the script.
     $localized_data['api_url'] = get_stylesheet_directory_uri();
-
-    // Add the API URL for the script
+    // Add the API URL for the script.
     $localized_data['site_id'] = get_current_blog_id();
-
-    // Create a nonce for the user
-    $localized_data['nonce']   = wp_create_nonce(WP_FORCE_REFRESH_ACTION);
-
-    // Add the ID of the handlebars notice
-    $localized_data['handlebars_admin_notice_template_id'] = WP_FORCE_REFRESH_HANDLEBARS_ADMIN_NOTICE_TEMPLATE_ID;
-
-    // Add the refresh interval
-    $localized_data['refresh_interval'] = get_option(WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS, WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT);
-
-    // Localize the data
-    wp_localize_script(
-        "force-refresh-main-admin-js",
-        "force_refresh_local_js",
-        $localized_data
+    // Create a nonce for the user.
+    $localized_data['nonce'] = wp_create_nonce( WP_FORCE_REFRESH_ACTION );
+    // Add the ID of the handlebars notice.
+    $localized_data['handlebars_admin_notice_template_id'] =
+      WP_FORCE_REFRESH_HANDLEBARS_ADMIN_NOTICE_TEMPLATE_ID;
+    // Add the refresh interval.
+    $localized_data['refresh_interval'] = get_option(
+        WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS,
+        WP_FORCE_REFRESH_OPTION_REFRESH_INTERVAL_IN_SECONDS_DEFAULT
     );
-
-    // Now that it's registered, enqueue the script
-    wp_enqueue_script("force-refresh-main-admin-js");
-
+    // Localize the data.
+    wp_localize_script( 'force-refresh-main-admin-js', 'force_refresh_local_js', $localized_data );
+    // Now that it's registered, enqueue the script.
+    wp_enqueue_script( 'force-refresh-main-admin-js' );
 }
 
 /**
  * Function for enqueueing styles for this plugin.
  *
- * @param     string    $handle    The stylesheet handle
- * @param     string    $path      The path to the stylesheet (relative to the CSS dist directory)
+ * @param string $handle The stylesheet handle.
+ * @param string $path The path to the stylesheet (relative to the CSS dist directory).
  *
- * @return    void
- *
- * @version 1.0 Introducted in version 1.0
+ * @return void
  */
-function add_style($handle, $path){
-
-    // Get the file path
+function add_style( $handle, $path ) {
+    // Get the file path.
     $file_path = get_force_refresh_plugin_directory() . $path;
-
-    // If the file doesn't exist, throw an error
-    if (!file_exists($file_path)){
-
-        echo "<div class=\"notice notice-error\">";
-        echo "<p>$path is missing.</p>";
-        echo "</div>";
-
-        // Log error to server
-        error_log("$path is missing.");
-    }
-
-    // Otherwise, work normally
-    else {
-
-        // Get the file version
-        $file_version = filemtime($file_path);
-
-        // Enqueue the style
-        wp_enqueue_style($handle, get_force_refresh_plugin_url($path), array(), $file_version);
-    }
+    // If the file doesn't exist, throw an error.
+  if ( ! file_exists( $file_path ) ) {
+      echo '<div class="notice notice-error">';
+      echo esc_html( "<p>${path} is missing.</p>" );
+      echo '</div>';
+  } else {
+    // Get the file version.
+    $file_version = filemtime( $file_path );
+    // Enqueue the style.
+    wp_enqueue_style( $handle, get_force_refresh_plugin_url( $path ), array(), $file_version );
+  }
 }
 
 /**
  * Function for adding scripts for this plugin.
  *
- * @param     string     $handle      The script handle
- * @param     string     $path        The path to the script (relative to the JS dist directory)
- * @param     boolean    $register    Whether we should simply register the script instead of enqueing it
+ * @param string  $handle The script handle.
  *
- * @return    void
+ * @param string  $path The path to the script (relative to the JS dist directory).
  *
- * @version 1.0 Introducted in version 1.0
+ * @param boolean $register Whether we should simply register the script instead of enqueing it.
  */
-function add_script($handle, $path, $register = false){
-
-    // Get the file path
+function add_script( $handle, $path, $register = false ) {
+    // Get the file path.
     $file_path = get_force_refresh_plugin_directory() . $path;
-
-    // If the file doesn't exist, throw an error
-    if (!file_exists($file_path)){
-
-        echo "<div class=\"notice notice-error\">";
-        echo "<p>$path is missing.</p>";
-        echo "</div>";
-
+    // If the file doesn't exist, throw an error.
+  if ( ! file_exists( $file_path ) ) {
+      echo '<div class="notice notice-error">';
+      echo esc_html( "<p>${path} is missing.</p>" );
+      echo '</div>';
+  } else {
+    // Get the file version.
+    $file_version = filemtime( $file_path );
+    // If we want to only register the script.
+    if ( $register ) {
+        wp_register_script(
+            $handle,
+            get_force_refresh_plugin_url( $path ),
+            array( 'jquery', 'jquery-ui-core' ),
+            $file_version,
+            true,
+        );
+    } else {
+        // Enqueue the style.
+        wp_enqueue_script(
+            $handle,
+            get_force_refresh_plugin_url( $path ),
+            array( 'jquery', 'jquery-ui-core' ),
+            $file_version,
+            true,
+        );
     }
-    // Otherwise, work normally
-    else {
-
-        // Get the file version
-        $file_version = filemtime($file_path);
-
-        // If we want to only register the script
-        if ($register){
-
-            wp_register_script($handle, get_force_refresh_plugin_url($path), array("jquery", "jquery-ui-core"), $file_version);
-
-        }
-
-        // Otherwise, we want to enqueue the script
-        else {
-
-            // Enqueue the style
-            wp_enqueue_script($handle, get_force_refresh_plugin_url($path), array("jquery", "jquery-ui-core"), $file_version);
-        }
-    }
+  }
 }
-
-?>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Force Refresh Coding Standards" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<file>.</file>
+	<!-- Exclude Composer vendor directory. -->
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+  <rule ref="WordPress">
+      <exclude name="Generic.WhiteSpace.DisallowSpaceIndent" />
+      <exclude name="WordPress.WhiteSpace.PrecisionAlignment.Found" />
+  </rule>
+  <rule ref="Generic.WhiteSpace.ScopeIndent">
+      <properties>
+          <property name="indent" value="2"/>
+          <property name="tabIndent" value="false"/>
+      </properties>
+  </rule>
+  <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
+      <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="100"/>
+            <property name="absoluteLineLimit" value="120"/>
+        </properties>
+     </rule>
+</ruleset>


### PR DESCRIPTION
<!-- PR title -->
# Add Support for PHP Linting

## Description
This PR adds support for PHP linting, and running linting as part of the CI process.
 

## Validation

- [ ] This PR has code changes, and our linters still pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down `chore--php-linting`.
1. Run `composer install && composer lint`.
- [ ] Confirm linting passes.

