### PR TITLE
fix: Address issue with encoded post names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8191,6 +8191,11 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "html-entities": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+      "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA=="
+    },
     "html-tags": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^0.20.0",
     "font-awesome": "^4.7.0",
     "handlebars": "^4.7.6",
+    "html-entities": "^1.3.1",
     "ramda": "^0.27.1",
     "regenerator-runtime": "^0.13.7",
     "sprintf-js": "^1.1.2",

--- a/src/components/AdminMetaBox.vue
+++ b/src/components/AdminMetaBox.vue
@@ -8,12 +8,12 @@
           @notification-closed="hideNotification"
         />
       </transition>
-      <p>Force all users to manually reload the {{ postType }} "{{ postName }}".</p>
+      <p>Force all users to manually reload the {{ postType }} "{{ postNameDecoded }}".</p>
       <button
         class="button button-primary"
         @click="refreshPage"
       >
-        Refresh {{ postName }}
+        Refresh {{ postNameDecoded }}
       </button>
     </div>
   </div>
@@ -21,6 +21,7 @@
 
 <script>
 import VueTypes from 'vue-types';
+import { AllHtmlEntities } from 'html-entities';
 import { sprintf } from 'sprintf-js';
 import { requestPostRefreshByPostID } from '../js/services/admin/refreshService';
 import AdminNotification from './AdminNotification.vue';
@@ -47,6 +48,9 @@ export default {
     };
   },
   computed: {
+    postNameDecoded() {
+      return AllHtmlEntities.decode(this.postName);
+    },
     notificationMessage() {
       return sprintf(MESSAGE_REFRESH_SUCCESS, this.refreshInterval);
     },


### PR DESCRIPTION
<!-- PR title -->
# Address issue with encoded post names

## Description
This PR fixes an issue where post names containing HTML entities (like `"` or `&`) would display encoded HTML entities in the post admin.

## Spec

See Issue: [25](https://github.com/jordanleven/force-refresh/issues/25)

## Validation
<!-- delete anything irrelevant to this PR -->

- [x] This PR has code changes, and our linters still pass.
- [x] This PR effects production code, so it was browser tested (see below).
- [x] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down all related branches.
1. Add a post with a title containing an HTML character.
- [ ] Confirm that the title appears as expected in the admin section.

On `master`
<img width="146" alt="Screen Shot 2020-11-28 at 4 13 11 PM" src="https://user-images.githubusercontent.com/7015466/100526207-be25c800-3194-11eb-9cb1-5083ccc215eb.png">

On `fe-25--postname-encoded`
<img width="262" alt="Screen Shot 2020-11-28 at 4 13 30 PM" src="https://user-images.githubusercontent.com/7015466/100526213-c8e05d00-3194-11eb-9e24-6ff981a3cf13.png">


