### PR TITLE
Fix: Infinite Refreshing on Search Pages

### DIFF
--- a/includes/api/classes/class-api-handler-admin-refresh-page.php
+++ b/includes/api/classes/class-api-handler-admin-refresh-page.php
@@ -59,13 +59,14 @@ class Api_Handler_Admin_Refresh_Page extends Api_Handler_Admin implements Api_Ha
         $page_id      = $request->get_param( 'postId' ) ?? null;
         $page_version = Versions_Storage_Service::get_new_version();
 
-        Versions_Storage_Service::set_page_version( $page_id, $site_version );
+        Versions_Storage_Service::set_page_version( $page_id, $page_version );
 
         $this->return_api_response(
             201,
             'You\'ve successfully requested all browsers to refresh this page.',
             array(
                 'new_page_version' => $page_version,
+                'page_id'          => $page_id,
                 'refresh_interval' => Options_Storage_Service::get_refresh_interval(),
             )
         );

--- a/includes/api/classes/class-api-handler-client.php
+++ b/includes/api/classes/class-api-handler-client.php
@@ -55,13 +55,18 @@ class Api_Handler_Client extends Api_Handler {
     public function get_version( \WP_REST_Request $request ): void {
         $post_id = $request->get_param( 'postId' ) ?? null;
 
+        $response = array(
+            'currentVersionSite' => $this->get_current_version_site(),
+        );
+
+        if ( $post_id ) {
+            $response['currentVersionPage'] = $this->get_current_version_post( $post_id );
+        }
+
         $this->return_api_response(
             200,
             'The current site version has been successfully retrieved.',
-            array(
-                'currentVersionSite' => $this->get_current_version_site(),
-                'currentVersionPage' => $post_id ? $this->get_current_version_post( $post_id ) : 0,
-            )
+            $response,
         );
     }
 

--- a/includes/services/classes/class-versions-storage-service.php
+++ b/includes/services/classes/class-versions-storage-service.php
@@ -14,7 +14,7 @@ class Versions_Storage_Service {
 
     const OPTION_SITE_VERSION = 'force_refresh_current_site_version';
 
-    const OPTION_PAGE_VERSION = 'force_refresh_current_site_version';
+    const OPTION_PAGE_VERSION = 'force_refresh_current_page_version';
 
     /**
      * Method for setting a site version.
@@ -34,11 +34,11 @@ class Versions_Storage_Service {
      * Method for setting a page version.
      *
      * @param int    $page_id The post ID to update.
-     * @param string $new_version The new site version.
+     * @param string $page_version The new site version.
      *
      * @return void
      */
-    public static function set_page_version( int $page_id, string $new_version ): void {
+    public static function set_page_version( int $page_id, string $page_version ): void {
         // Remove the old.
         delete_post_meta( $page_id, self::OPTION_PAGE_VERSION );
 

--- a/src/js/client/client.js
+++ b/src/js/client/client.js
@@ -1,6 +1,7 @@
 import 'regenerator-runtime/runtime';
 import {
   __,
+  always,
   anyPass,
   curry,
   identity,
@@ -36,12 +37,16 @@ const isSiteVersionOutdated = ({ currentVersionSite }) => pipe(
   )('Site', __, currentVersionSite),
 )();
 
-const isPageVersionOutdated = ({ currentVersionPage }) => pipe(
-  getStoredVersionPage,
-  curry(
-    isVersionOutdated,
-  )('Page', __, currentVersionPage),
-)();
+const isPageVersionOutdated = ({ currentVersionPage }) => ifElse(
+  (v) => v !== undefined,
+  (v) => pipe(
+    getStoredVersionPage,
+    curry(
+      isVersionOutdated,
+    )('Page', __, v),
+  )(),
+  always(false),
+)(currentVersionPage);
 
 const storeVersionSite = (version) => pipe(
   tap(
@@ -76,7 +81,10 @@ const pageRequiresRefresh = (versions) => anyPass([
 
 const maybeStoreVersions = ({ currentVersionSite, currentVersionPage }) => {
   maybeStoreVersionSite(currentVersionSite);
-  maybeStoreVersionPage(currentVersionPage);
+
+  if (currentVersionPage !== undefined) {
+    maybeStoreVersionPage(currentVersionPage);
+  }
 };
 
 const refreshPage = ({ currentVersionSite, currentVersionPage }) => {
@@ -114,6 +122,7 @@ const checkForRefresh = async () => {
     exitForceRefresh();
     return;
   }
+
   compareRetrievedVersions(data);
 };
 

--- a/src/js/client/currentVersions.js
+++ b/src/js/client/currentVersions.js
@@ -3,14 +3,22 @@ import { debug } from '@/js/services/loggingService.js';
 
 const apiClient = apiService();
 
+const getCurrentVersionPayload = (postId) => {
+  if (!postId) {
+    return {};
+  }
+
+  return { postId };
+};
+
 export const getCurrentVersion = async () => {
   // eslint-disable-next-line no-undef
   const { apiEndpoint, postId } = forceRefreshLocalizedData;
 
-  debug(`Requesting refresh data for site and post ${postId}.`);
-  const payload = {
-    postId,
-  };
+  const message = postId ? ` and post ${postId}` : '';
 
+  debug(`Requesting refresh data for site${message}.`);
+
+  const payload = getCurrentVersionPayload(postId);
   return apiClient.get(apiEndpoint, payload);
 };


### PR DESCRIPTION
## Description
<!-- Add description of work done here -->
This PR fixes an issue where pages without valid post IDs (like search pages) results in infinite refreshing since the version numbers for non-existant posts could not be found.
