### PR TITLE
Fix: Missing refresh interval in admin bar success message

### DIFF
--- a/src/layouts/LayoutAdminBar.vue
+++ b/src/layouts/LayoutAdminBar.vue
@@ -22,6 +22,7 @@ import Vue from 'vue';
 import VueTypes from 'vue-types';
 import { mapActions, mapGetters } from 'vuex';
 import AdminFooterNotification from '@/components/AdminFooterNotification/AdminFooterNotification.vue';
+import { getRefreshIntervalUnitAndValue } from '@/js/utilities/getRefreshIntervalUnitAndValue.js';
 
 library.add([faSyncAlt]);
 
@@ -81,7 +82,11 @@ export default {
       const success = await this.requestRefreshSite();
 
       if (success) {
-        this.notificationMessage = this.$t('ADMIN_NOTIFICATIONS.SITE_REFRESHED_SUCCESS', { refreshInterval: this.refreshInterval });
+        const [refreshIntervalValue, refreshIntervalUnit] = getRefreshIntervalUnitAndValue(this.refreshInterval);
+        this.notificationMessage = this.$t('ADMIN_NOTIFICATIONS.SITE_REFRESHED_SUCCESS', {
+          refreshIntervalUnit,
+          refreshIntervalValue,
+        });
       } else {
         this.notificationMessage = this.$t('ADMIN_NOTIFICATIONS.SITE_REFRESHED_FAILURE');
       }


### PR DESCRIPTION
## Description
<!-- Add description of work done here -->
This small PR fixes an issue where users who refresh the site from the admin bar would be missing the refresh interval from the success message.
