### PR TITLE
Interactive Version Picker for Release Scripts

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -6,22 +6,78 @@ getCurrentBranchName() {
   git branch | sed -n -e 's/^\* \(.*\)/\1/p'
 }
 
-getReleaseOverride() {
-  release_option=$1
-  case $release_option in
-    --major) echo 'major' ;;
-    --minor) echo 'minor' ;;
-    --patch) echo 'patch' ;;
-    *)       echo ''      ;;
-  esac
+getNextVersion() {
+  release_kind=$1
+  npx changie next "$release_kind"
 }
 
-getNextVersion() {
-  override=$1
-  if [ -n "$override" ]; then
-    npx changie next "$override"
+appendUniqueOption() {
+  version=$1
+  label=$2
+
+  [ -n "$version" ] || return
+  [ "$version" = "$option_1_version" ] && return
+  [ "$version" = "$option_2_version" ] && return
+  [ "$version" = "$option_3_version" ] && return
+  [ "$version" = "$option_4_version" ] && return
+
+  if [ -z "$option_1_version" ]; then
+    option_1_version=$version
+    option_1="${version}  (${label})"
+  elif [ -z "$option_2_version" ]; then
+    option_2_version=$version
+    option_2="${version}  (${label})"
+  elif [ -z "$option_3_version" ]; then
+    option_3_version=$version
+    option_3="${version}  (${label})"
+  elif [ -z "$option_4_version" ]; then
+    option_4_version=$version
+    option_4="${version}  (${label})"
+  fi
+}
+
+selectReleaseVersion() {
+  auto_version=$(getNextVersion auto)
+  major_version=$(getNextVersion major)
+  minor_version=$(getNextVersion minor)
+  patch_version=$(getNextVersion patch)
+
+  option_1_version=''
+  option_2_version=''
+  option_3_version=''
+  option_4_version=''
+  option_1=''
+  option_2=''
+  option_3=''
+  option_4=''
+
+  appendUniqueOption "$auto_version" auto
+  appendUniqueOption "$major_version" major
+  appendUniqueOption "$minor_version" minor
+  appendUniqueOption "$patch_version" patch
+
+  if [ -n "$option_4" ]; then
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1" \
+      "$option_2" \
+      "$option_3" \
+      "$option_4"
+  elif [ -n "$option_3" ]; then
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1" \
+      "$option_2" \
+      "$option_3"
+  elif [ -n "$option_2" ]; then
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1" \
+      "$option_2"
   else
-    npx changie next auto
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1"
   fi
 }
 
@@ -51,7 +107,6 @@ bumpVersion() {
 }
 
 current_branch=$(getCurrentBranchName)
-release_override=$(getReleaseOverride "$1")
 
 if [ "$current_branch" != "$production_branch" ]; then
   printf "\033[1;31mCannot release while on branch %s\n\033[0m" "$current_branch"
@@ -63,18 +118,16 @@ if ! hasUnreleasedFragments; then
   exit 1
 fi
 
-next_version=$(getNextVersion "$release_override")
+selection=$(selectReleaseVersion) || {
+  printf "\033[1;31mRelease was aborted.\033[0m\n"
+  exit 1
+}
+
+next_version=${selection%%  *}
 
 printf "\033[37m=====================\033[0m\n"
 printf "\033[37m%s\033[0m\n" "Preparing to release version ${next_version}."
-printf "\033[33m\n\nPress \"y\" to proceed with this release or press any other key to abort.\033[0m\n"
 
-read -r REPLY
-if echo "$REPLY" | grep -q "^[Yy]$"
-then
-  bumpVersion "$next_version"
-  git push --follow-tags
-  printf "\033[1;32mPackage successfully updated and pushed to the remote.\033[0m\n"
-else
-  printf "\033[1;31mRelease was aborted.\033[0m\n"
-fi
+bumpVersion "$next_version"
+git push --follow-tags
+printf "\033[1;32mPackage successfully updated and pushed to the remote.\033[0m\n"

--- a/.github/scripts/releaseBeta.sh
+++ b/.github/scripts/releaseBeta.sh
@@ -9,6 +9,9 @@ getCurrentBranchName() {
 getPrereleaseName() {
   current_branch_name=$(getCurrentBranchName)
   commit_sha=$(git log master.."$current_branch_name" --oneline --format=format:%H | tail -1)
+  if [ -z "$commit_sha" ]; then
+    commit_sha=$(git rev-parse HEAD)
+  fi
   prerelease_name=$(echo "$commit_sha" | cut -c1-6 | awk '{ print toupper($0) }')
   echo "$prerelease_name"
 }
@@ -26,7 +29,8 @@ hasUnreleasedFragments() {
 }
 
 getNextBaseVersion() {
-  npx changie next auto
+  release_kind=$1
+  npx changie next "$release_kind"
 }
 
 getExistingBuildNumber() {
@@ -65,7 +69,7 @@ getNextBetaReleaseVersion() {
 }
 
 getBetaReleaseVersion() {
-  next_base=$(getNextBaseVersion)
+  next_base=$1
   current_base=$(getCurrentBaseVersion)
   prerelease_name=$(getPrereleaseName)
 
@@ -78,6 +82,76 @@ getBetaReleaseVersion() {
   echo "$beta_release_version"
 }
 
+appendUniqueOption() {
+  version=$1
+  label=$2
+
+  [ -n "$version" ] || return
+  [ "$version" = "$option_1_version" ] && return
+  [ "$version" = "$option_2_version" ] && return
+  [ "$version" = "$option_3_version" ] && return
+  [ "$version" = "$option_4_version" ] && return
+
+  if [ -z "$option_1_version" ]; then
+    option_1_version=$version
+    option_1="${version}  (${label})"
+  elif [ -z "$option_2_version" ]; then
+    option_2_version=$version
+    option_2="${version}  (${label})"
+  elif [ -z "$option_3_version" ]; then
+    option_3_version=$version
+    option_3="${version}  (${label})"
+  elif [ -z "$option_4_version" ]; then
+    option_4_version=$version
+    option_4="${version}  (${label})"
+  fi
+}
+
+selectReleaseVersion() {
+  auto_version=$(getBetaReleaseVersion "$(getNextBaseVersion auto)")
+  major_version=$(getBetaReleaseVersion "$(getNextBaseVersion major)")
+  minor_version=$(getBetaReleaseVersion "$(getNextBaseVersion minor)")
+  patch_version=$(getBetaReleaseVersion "$(getNextBaseVersion patch)")
+
+  option_1_version=''
+  option_2_version=''
+  option_3_version=''
+  option_4_version=''
+  option_1=''
+  option_2=''
+  option_3=''
+  option_4=''
+
+  appendUniqueOption "$auto_version" auto
+  appendUniqueOption "$major_version" major
+  appendUniqueOption "$minor_version" minor
+  appendUniqueOption "$patch_version" patch
+
+  if [ -n "$option_4" ]; then
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1" \
+      "$option_2" \
+      "$option_3" \
+      "$option_4"
+  elif [ -n "$option_3" ]; then
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1" \
+      "$option_2" \
+      "$option_3"
+  elif [ -n "$option_2" ]; then
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1" \
+      "$option_2"
+  else
+    node "$(dirname "$0")/selectVersion.js" \
+      "Select a version to release" \
+      "$option_1"
+  fi
+}
+
 current_branch=$(getCurrentBranchName)
 
 if ! hasUnreleasedFragments; then
@@ -85,24 +159,22 @@ if ! hasUnreleasedFragments; then
   exit 1
 fi
 
-next_version=$(getBetaReleaseVersion)
-
 if [ "$current_branch" = "$production_branch" ]
   then
   printf "\033[1;31mCannot release betas while on branch %s\n\033[0m" "$production_branch"
   exit 1
 fi
 
+selection=$(selectReleaseVersion) || {
+  printf "\033[1;31mRelease was aborted.\033[0m\n\n"
+  exit 1
+}
+
+next_version=${selection%%  *}
+
 printf "\033[37m=====================\033[0m\n"
 printf "\033[37mPreparing to release beta version %s.\033[0m\n\n" "$next_version"
-printf "\033[33mPress \"y\" to proceed with this beta release or press any other key to abort.\033[0m "
 
-read -r REPLY
-if echo "$REPLY" | grep -q "^[Yy]$"
-then
-  bumpVersionPackage "$next_version"
-  git push --force-with-lease --follow-tags
-  printf "\033[1;32m\n\nPackage succesfully updated and pushed to the remote.\033[0m\n\n"
-else
-  printf "\033[1;31mRelease was aborted.\033[0m\n\n"
-fi
+bumpVersionPackage "$next_version"
+git push --force-with-lease --follow-tags
+printf "\033[1;32m\n\nPackage succesfully updated and pushed to the remote.\033[0m\n\n"

--- a/.github/scripts/selectVersion.js
+++ b/.github/scripts/selectVersion.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+const readline = require('readline');
+
+const [, , title, ...options] = process.argv;
+
+if (!title || options.length === 0) {
+  process.stderr.write('Usage: selectVersion.js "<title>" "<option 1>" ["<option 2>" ...]>\n');
+  process.exit(1);
+}
+
+let selectedIndex = 0;
+let inputBuffer = '';
+let hasRendered = false;
+let renderedLineCount = 0;
+const output = process.stderr;
+const ANSI_RESET = '\u001b[0m';
+const ANSI_BOLD = '\u001b[1m';
+const ANSI_CYAN = '\u001b[36m';
+const ANSI_GREEN = '\u001b[32m';
+const ANSI_DIM = '\u001b[2m';
+const ANSI_HIDE_CURSOR = '\u001b[?25l';
+const ANSI_SHOW_CURSOR = '\u001b[?25h';
+
+function renderMenu() {
+  if (hasRendered) {
+    readline.moveCursor(output, 0, -(renderedLineCount - 1));
+    readline.cursorTo(output, 0);
+  } else {
+    output.write(ANSI_HIDE_CURSOR);
+  }
+
+  readline.clearScreenDown(output);
+
+  output.write(`${ANSI_CYAN}? ${title} ›${ANSI_RESET}\n`);
+
+  options.forEach((option, index) => {
+    const prefix = index === selectedIndex ? '❯' : ' ';
+    if (index === selectedIndex) {
+      output.write(`${ANSI_BOLD}${ANSI_GREEN}${prefix} ${option}${ANSI_RESET}\n`);
+      return;
+    }
+
+    output.write(`${prefix} ${option}\n`);
+  });
+
+  output.write(`${ANSI_DIM}↑/↓ navigate • enter confirm • q quit${ANSI_RESET}`);
+  hasRendered = true;
+  renderedLineCount = options.length + 2;
+}
+
+function cleanupAndExit(exitCode, selectedOption = '') {
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(false);
+  }
+
+  process.stdin.pause();
+  output.write(`${ANSI_SHOW_CURSOR}\n`);
+
+  if (selectedOption) {
+    process.stdout.write(selectedOption);
+  }
+
+  process.exit(exitCode);
+}
+
+function moveSelection(offset) {
+  const nextIndex = selectedIndex + offset;
+
+  if (nextIndex < 0) {
+    selectedIndex = options.length - 1;
+  } else if (nextIndex >= options.length) {
+    selectedIndex = 0;
+  } else {
+    selectedIndex = nextIndex;
+  }
+
+  renderMenu();
+}
+
+function consumeBuffer() {
+  while (inputBuffer.length > 0) {
+    switch (true) {
+      case inputBuffer.startsWith('\u001b[A'):
+        inputBuffer = inputBuffer.slice(3);
+        moveSelection(-1);
+        break;
+
+      case inputBuffer.startsWith('\u001b[B'):
+        inputBuffer = inputBuffer.slice(3);
+        moveSelection(1);
+        break;
+
+      case inputBuffer[0] === '\r':
+      case inputBuffer[0] === '\n':
+        cleanupAndExit(0, options[selectedIndex]);
+        return;
+
+      case inputBuffer[0] === 'q':
+      case inputBuffer[0] === 'Q':
+      case inputBuffer[0] === '\u0003':
+        cleanupAndExit(1);
+        return;
+
+      case inputBuffer[0] === '\u001b' && inputBuffer.length < 3:
+        return;
+
+      default:
+        inputBuffer = inputBuffer.slice(1);
+    }
+  }
+}
+
+readline.emitKeypressEvents(process.stdin);
+
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true);
+}
+
+process.stdin.resume();
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  inputBuffer += chunk;
+  consumeBuffer();
+});
+
+process.stdin.on('end', () => {
+  cleanupAndExit(1);
+});
+
+renderMenu();


### PR DESCRIPTION
## Description

Replaces the y/n confirmation in \`release.sh\` and \`releaseBeta.sh\` with an arrow-key version picker matching changie's interface. A new \`selectVersion.js\` Node script handles the interactive menu — rendering to stderr, printing the selection to stdout — which the shell scripts call and capture.

## Spec

See Issue: [ISSUE_NUMBER](https://github.com/jordanleven/force-refresh/issues/ISSUE_NUMBER)

## Validation

- [x] This PR has code changes, and our linters still pass.
- [ ] This PR effects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. On a feature branch with unreleased changie fragments, run `npm run release:beta` — arrow keys should move the `❯` cursor, Enter should confirm, `q` should abort.
1. On `master` with unreleased fragments, run `npm run release` — same interaction.