### PR TITLE
Apply Card Surface Styles to Main Page

### DIFF
--- a/src/components/AdminMainOptions/AdminMainOptions.vue
+++ b/src/components/AdminMainOptions/AdminMainOptions.vue
@@ -268,9 +268,7 @@ export default {
 
 .force-refresh-admin__options-inner {
   padding: 0 20px 10px;
-  background-color: white;
-  border: 2px solid var.$light-grey;
-  border-radius: 10px;
+  @include utils.card-surface;
 
   @include utils.small {
     margin-left: 10px;

--- a/src/components/AdminMainRefresh/AdminMainRefresh.vue
+++ b/src/components/AdminMainRefresh/AdminMainRefresh.vue
@@ -120,9 +120,7 @@ export default {
   width: 100%;
   padding: 20px 10px 30px;
   text-align: center;
-  border: 2px solid var.$light-grey;
-  border-radius: 10px;
-  background-color: white;
+  @include utils.card-surface;
 }
 
 .admin__refresh-logo {

--- a/src/scss/utilities/_mixin-card.scss
+++ b/src/scss/utilities/_mixin-card.scss
@@ -1,7 +1,7 @@
 @use "@/scss/variables" as var;
 
 $card-blur-default: blur(28px) saturate(1.8);
-$card-shadow-default: 0 8px 32px rgba(var.$black, 0.1), 0 2px 8px rgba(var.$black, 0.06), inset 0 1px 0 rgba(var.$white, 0.8);
+$card-shadow-default: 0 8px 32px rgba(var.$black, 0.06), 0 2px 8px rgba(var.$black, 0.03), inset 0 1px 0 rgba(var.$white, 0.8);
 $card-radius-default: 0.75rem;
 
 @mixin card-surface($bg: var.$card-surface) {


### PR DESCRIPTION
## Description
This updates the main admin page to use the shared `card-surface` mixin for the refresh and options panels instead of duplicating their border, radius, and background styles inline.

It also slightly softens the shared card shadow so the refreshed card treatment feels lighter and more consistent across the admin UI.

## Spec
See Issue: No linked issue for this styling cleanup.

## Validation
- [ ] This PR has code changes, and our linters still pass.
- [ ] This PR effects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down `feat--update-styles-on-main-page`.
1. Start the local environment and open the Force Refresh admin page.
1. Confirm the main refresh panel and options panel now share the same card treatment.
1. Verify the updated shadow still reads clearly against the page background and does not make the cards feel heavier than the surrounding UI.

---

### Browser Testing

- [ ] Mac: Safari 13
- [ ] Mac: Safari 12
- [ ] Mac: Chrome Latest
- [ ] Mac: Firefox Latest
- [ ] Windows: Edge
- [ ] Windows Chrome
- [ ] Windows: Firefox
- [ ] Windows: IE11
- [ ] iOS 13: Safari
- [ ] iOS 13: Chrome
- [ ] iOS 12: Safari
- [ ] iOS 12: Chrome
- [ ] Android 9: Chrome
- [ ] Android 8: Chrome
