### PR TITLE
Fix Mobile Styling Overflow Issues

### DIFF
--- a/src/components/AdminMain/AdminMain.vue
+++ b/src/components/AdminMain/AdminMain.vue
@@ -51,6 +51,7 @@ $options-max-width: 30rem;
 
 .force-refresh__main,
 .force-refresh-admin__options {
+  box-sizing: border-box;
   width: 100%;
   margin-bottom: 1rem;
 }

--- a/src/components/AdminMainRefresh/AdminMainRefresh.vue
+++ b/src/components/AdminMainRefresh/AdminMainRefresh.vue
@@ -138,6 +138,7 @@ export default {
 .admin__refresh-buttons {
   position: relative;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
 }
 


### PR DESCRIPTION
## Description

Fixes two overflow issues affecting the plugin's admin UI on smaller screens.

**`.admin__refresh-buttons` overflow** — The flex container holding the refresh buttons had no wrapping enabled, causing buttons to overflow their parent's width on narrow viewports. Added `flex-wrap: wrap` so buttons stack vertically when there isn't enough horizontal space.

**`.force-refresh__main` / `.force-refresh-admin__options` overflow** — These elements use `width: 100%`, but without `box-sizing: border-box`, any padding applied was added on top of that width, pushing them past their container. Added `box-sizing: border-box` to include padding in the computed width.

## Spec

No associated issue.

## Validation

- [x] This PR has code changes, and our linters still pass.
- [x] This PR effects production code, so it was browser tested (see below).
- [ ] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down the branch.
1. Navigate to the Force Refresh admin page on a narrow viewport (e.g. mobile width ~375px).
1. Verify the refresh buttons wrap onto a new line rather than overflowing horizontally.
1. Verify the main content and options panels do not overflow their container width.

---

### Browser Testing

- [ ] Mac: Safari 13
- [ ] Mac: Safari 12
- [ ] Mac: Chrome Latest
- [ ] Mac: Firefox Latest
- [ ] Windows: Edge
- [ ] Windows Chrome
- [ ] Windows: Firefox
- [ ] Windows: IE11
- [ ] iOS 13: Safari
- [ ] iOS 13: Chrome
- [ ] iOS 12: Safari
- [ ] iOS 12: Chrome
- [ ] Android 9: Chrome
- [ ] Android 8: Chrome