### PR TITLE
Update Beta Install Instructions

### DIFF
--- a/docs/Beta-Releases.md
+++ b/docs/Beta-Releases.md
@@ -4,9 +4,10 @@ If you're encountering errors with Force Refresh, I may ask for you to download 
 
 ## Installing Beta Versions
 
-1. Download the beta release directly from GitHub using the provided link.
+1. Download the beta release `.zip` from GitHub using the provided link.
 1. Under "Plugins", [deactivate][help_deactivate_plugin] the existing Force Refresh plugin.
-1. Upload the beta release of Force Refresh using your preferred method, like FTP or uploading through the UI as a .zip file.
+1. In WordPress admin, go to **Plugins > Add New Plugin > Upload Plugin**.
+1. Choose the downloaded `.zip` file and click **Install Now**.
 1. Activate the beta release of Force Refresh under Plugins.
 
 ## Uninstalling Beta Versions


### PR DESCRIPTION
## Description

Rewrites the beta plugin installation instructions in `docs/Beta-Releases.md` to remove the vague FTP reference and replace it with explicit, step-by-step instructions for installing through the WordPress admin UI.

**Before:** Step 3 said to upload the release \"using your preferred method, like FTP or uploading through the UI as a .zip file\" — no clear guidance on how to actually do it.

**After:** The steps now walk users directly through the WordPress admin upload flow: download the zip, navigate to **Plugins > Add New Plugin > Upload Plugin**, choose the file, and install.

## Spec

This is a documentation-only change with no linked issue.

## Validation

- [ ] This PR has code changes, and our linters still pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Review `docs/Beta-Releases.md` and confirm the install steps are clear, accurate, and contain no FTP references.