### PR TITLE
Track Admin Refresh Counts by Type

### DIFF
--- a/includes/api/classes/class-api-handler-admin-refresh-page.php
+++ b/includes/api/classes/class-api-handler-admin-refresh-page.php
@@ -10,7 +10,7 @@ namespace JordanLeven\Plugins\ForceRefresh\Api;
 use JordanLeven\Plugins\ForceRefresh\Api\Api_Handler_Admin;
 use JordanLeven\Plugins\ForceRefresh\Api\Interfaces\Api_Handler_Admin_Interface;
 use JordanLeven\Plugins\ForceRefresh\Services\Options_Storage_Service;
-use JordanLeven\Plugins\ForceRefresh\Services\Versions_Storage_Service;
+use JordanLeven\Plugins\ForceRefresh\Services\Refresh_Service;
 
 /**
  * Main class controller.
@@ -57,9 +57,7 @@ class Api_Handler_Admin_Refresh_Page extends Api_Handler_Admin implements Api_Ha
      */
     public function refresh_page( \WP_REST_Request $request ): \WP_REST_Response {
         $page_id      = $request->get_param( 'postId' ) ?? null;
-        $page_version = Versions_Storage_Service::get_new_version();
-
-        Versions_Storage_Service::set_page_version( $page_id, $page_version );
+        $page_version = Refresh_Service::update_version_page( $page_id );
 
         return $this->return_api_response(
             \WP_Http::CREATED,

--- a/includes/api/classes/class-api-handler-admin-refresh-site.php
+++ b/includes/api/classes/class-api-handler-admin-refresh-site.php
@@ -9,7 +9,7 @@ namespace JordanLeven\Plugins\ForceRefresh\Api;
 
 use JordanLeven\Plugins\ForceRefresh\Api\Api_Handler_Admin;
 use JordanLeven\Plugins\ForceRefresh\Api\Interfaces\Api_Handler_Admin_Interface;
-use JordanLeven\Plugins\ForceRefresh\Services\Versions_Storage_Service;
+use JordanLeven\Plugins\ForceRefresh\Services\Refresh_Service;
 
 /**
  * Main class controller.
@@ -53,9 +53,7 @@ class Api_Handler_Admin_Refresh_Site extends Api_Handler_Admin implements Api_Ha
      * @return \WP_REST_Response
      */
     public function refresh_site(): \WP_REST_Response {
-        $site_version = Versions_Storage_Service::get_new_version();
-
-        Versions_Storage_Service::set_site_version( $site_version );
+        $site_version = Refresh_Service::update_version_site();
 
         return $this->return_api_response(
             \WP_Http::CREATED,

--- a/includes/api/classes/class-api-handler-admin-schedule-refresh-site.php
+++ b/includes/api/classes/class-api-handler-admin-schedule-refresh-site.php
@@ -9,7 +9,7 @@ namespace JordanLeven\Plugins\ForceRefresh\Api;
 
 use JordanLeven\Plugins\ForceRefresh\Api\Api_Handler_Admin;
 use JordanLeven\Plugins\ForceRefresh\Api\Interfaces\Api_Handler_Admin_Interface;
-use JordanLeven\Plugins\ForceRefresh\Services\Versions_Storage_Service;
+use JordanLeven\Plugins\ForceRefresh\Services\Refresh_Service;
 
 /**
  * Main class controller.
@@ -121,8 +121,7 @@ class Api_Handler_Admin_Schedule_Refresh_Site extends Api_Handler_Admin implemen
      * @return  void
      */
     public function executeSiteRefresh( string $uuid ): void {
-        $site_version = Versions_Storage_Service::get_new_version();
-        Versions_Storage_Service::set_site_version( $site_version );
+        Refresh_Service::update_version_site();
     }
 
     /**

--- a/includes/services/classes/class-refresh-counter-service.php
+++ b/includes/services/classes/class-refresh-counter-service.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Our class responsible for tracking admin-initiated refresh counts.
+ *
+ * @package ForceRefresh
+ */
+
+namespace JordanLeven\Plugins\ForceRefresh\Services;
+
+/**
+ * Class for tracking refresh counts by type.
+ */
+class Refresh_Counter_Service {
+
+    const OPTION_SITE_REFRESH_COUNT = 'force_refresh_refresh_count_site';
+
+    const OPTION_PAGE_REFRESH_COUNTS = 'force_refresh_refresh_count_page';
+
+    /**
+     * Get the total number of site-wide refreshes.
+     *
+     * @return int
+     */
+    public static function get_refresh_count_site(): int {
+        return (int) get_option( self::OPTION_SITE_REFRESH_COUNT, 0 );
+    }
+
+    /**
+     * Get the number of refreshes for a specific page.
+     *
+     * @param int $page_id The post ID to look up.
+     *
+     * @return int
+     */
+    public static function get_refresh_count_page( int $page_id ): int {
+        $raw    = get_option( self::OPTION_PAGE_REFRESH_COUNTS, array() );
+        $counts = is_array( $raw ) ? $raw : array();
+        $key    = (string) $page_id;
+        $count  = $counts[ $key ] ?? 0;
+        return (int) $count;
+    }
+
+    /**
+     * Increment the site-wide refresh count.
+     *
+     * @return void
+     */
+    public static function increment_site_refresh_count(): void {
+        update_option( self::OPTION_SITE_REFRESH_COUNT, self::get_refresh_count_site() + 1 );
+    }
+
+    /**
+     * Increment the refresh count for a specific page.
+     *
+     * @param int $page_id The post ID to increment.
+     *
+     * @return void
+     */
+    public static function increment_page_refresh_count( int $page_id ): void {
+        $raw            = get_option( self::OPTION_PAGE_REFRESH_COUNTS, array() );
+        $counts         = is_array( $raw ) ? $raw : array();
+        $key            = (string) $page_id;
+        $current        = self::get_refresh_count_page( $page_id );
+        $counts[ $key ] = $current + 1;
+        update_option( self::OPTION_PAGE_REFRESH_COUNTS, $counts );
+    }
+}

--- a/includes/services/classes/class-refresh-service.php
+++ b/includes/services/classes/class-refresh-service.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Our class responsible for coordinating site and page refreshes.
+ *
+ * @package ForceRefresh
+ */
+
+namespace JordanLeven\Plugins\ForceRefresh\Services;
+
+use JordanLeven\Plugins\ForceRefresh\Services\Refresh_Counter_Service;
+use JordanLeven\Plugins\ForceRefresh\Services\Versions_Storage_Service;
+
+/**
+ * Class for refresh operations.
+ */
+class Refresh_Service {
+
+    /**
+     * Generate a new version, persist it as the site version, increment the
+     * site refresh counter, and return the new version.
+     *
+     * @return string The new site version.
+     */
+    public static function update_version_site(): string {
+        $version = self::get_new_version();
+        Versions_Storage_Service::set_site_version( $version );
+        Refresh_Counter_Service::increment_site_refresh_count();
+        return $version;
+    }
+
+    /**
+     * Generate a new version, persist it as the page version, increment the
+     * page refresh counter, and return the new version.
+     *
+     * @param int $page_id The post ID to refresh.
+     *
+     * @return string The new page version.
+     */
+    public static function update_version_page( int $page_id ): string {
+        $version = self::get_new_version();
+        Versions_Storage_Service::set_page_version( $page_id, $version );
+        Refresh_Counter_Service::increment_page_refresh_count( $page_id );
+        return $version;
+    }
+
+    /**
+     * Generate a new unique version string.
+     *
+     * @return string
+     */
+    private static function get_new_version(): string {
+        return Versions_Storage_Service::get_new_version();
+    }
+}

--- a/includes/services/classes/class-versions-storage-service.php
+++ b/includes/services/classes/class-versions-storage-service.php
@@ -95,7 +95,7 @@ class Versions_Storage_Service {
             $data['pages'] = $page_versions;
         }
 
-        Version_File_Service::write( $data );
+        self::write_version_file( $data );
     }
 
     /**
@@ -132,7 +132,16 @@ class Versions_Storage_Service {
             $merged['pages'] = $merged_pages;
         }
 
-        Version_File_Service::write( $merged );
+        self::write_version_file( $merged );
+    }
+
+    /**
+     * Write data to the version file.
+     *
+     * @param array $data The data to write.
+     */
+    private static function write_version_file( array $data ): void {
+        Version_File_Service::write( $data );
     }
 
     /**

--- a/test/api/classes/ApiHandlerAdminRefreshPageTest.php
+++ b/test/api/classes/ApiHandlerAdminRefreshPageTest.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../../includes/api/classes/class-api-handler-admin.p
 require_once __DIR__ . '/../../../includes/services/classes/class-version-file-service.php';
 require_once __DIR__ . '/../../../includes/services/classes/class-options-storage-service.php';
 require_once __DIR__ . '/../../../includes/services/classes/class-versions-storage-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-refresh-counter-service.php';
 require_once __DIR__ . '/../../../includes/api/classes/class-api-handler-admin-refresh-page.php';
 
 /**
@@ -198,7 +199,7 @@ final class ApiHandlerAdminRefreshPageTest extends TestCase {
         ( new Api_Handler_Admin_Refresh_Page() )->refresh_page( $request );
         ob_get_clean();
 
-        $args = self::$mock_update_option_services->get_last_invocation_arguments();
+        $args = self::$mock_update_option_services->get_invocation_arguments( 0 );
         $this->assertSame( 'force_refresh_page_versions', $args[0] );
         $this->assertArrayHasKey( (string) $post_id, $args[1] );
     }

--- a/test/api/classes/ApiHandlerAdminRefreshSiteTest.php
+++ b/test/api/classes/ApiHandlerAdminRefreshSiteTest.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../../includes/api/classes/class-api-handler-admin.p
 require_once __DIR__ . '/../../../includes/services/classes/class-version-file-service.php';
 require_once __DIR__ . '/../../../includes/services/classes/class-options-storage-service.php';
 require_once __DIR__ . '/../../../includes/services/classes/class-versions-storage-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-refresh-counter-service.php';
 require_once __DIR__ . '/../../../includes/api/classes/class-api-handler-admin-refresh-site.php';
 
 /**
@@ -107,6 +108,13 @@ final class ApiHandlerAdminRefreshSiteTest extends TestCase {
     private static $mock_get_option_services;
 
     /**
+     * Mock for `update_option` in the services namespace.
+     *
+     * @var Mocks\Mock_Update_Option
+     */
+    private static $mock_update_option_services;
+
+    /**
      * Mock for `wp_upload_dir` in the services namespace.
      *
      * @var Mocks\Mock_Wp_Upload_Dir
@@ -137,6 +145,7 @@ final class ApiHandlerAdminRefreshSiteTest extends TestCase {
         self::$mock_get_rest_url           = new Mocks\Mock_Get_Rest_Url( __NAMESPACE__ );
         self::$mock_current_user_can       = new Mocks\Mock_Current_User_Can( __NAMESPACE__ );
         self::$mock_get_option_services    = new Mocks\Mock_Get_Option( self::SERVICES_NAMESPACE );
+        self::$mock_update_option_services = new Mocks\Mock_Update_Option( self::SERVICES_NAMESPACE );
         self::$mock_wp_upload_dir_services = new Mocks\Mock_Wp_Upload_Dir( self::SERVICES_NAMESPACE );
         self::$mock_wp_mkdir_p_services    = new Mocks\Mock_Wp_Mkdir_P( self::SERVICES_NAMESPACE );
 
@@ -167,6 +176,7 @@ final class ApiHandlerAdminRefreshSiteTest extends TestCase {
         self::$mock_get_rest_url->disable();
         self::$mock_current_user_can->disable();
         self::$mock_get_option_services->disable();
+        self::$mock_update_option_services->disable();
         self::$mock_wp_upload_dir_services->disable();
         self::$mock_wp_mkdir_p_services->disable();
     }

--- a/test/api/classes/ApiHandlerAdminScheduleRefreshSiteTest.php
+++ b/test/api/classes/ApiHandlerAdminScheduleRefreshSiteTest.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/../../../includes/api/classes/class-api-handler-admin.p
 require_once __DIR__ . '/../../../includes/services/classes/class-version-file-service.php';
 require_once __DIR__ . '/../../../includes/services/classes/class-options-storage-service.php';
 require_once __DIR__ . '/../../../includes/services/classes/class-versions-storage-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-refresh-counter-service.php';
 require_once __DIR__ . '/../../../includes/api/classes/class-api-handler-admin-schedule-refresh-site.php';
 
 /**
@@ -142,6 +143,13 @@ final class ApiHandlerAdminScheduleRefreshSiteTest extends TestCase {
     private static $mock_get_option_services;
 
     /**
+     * Mock for `update_option` in the services namespace.
+     *
+     * @var Mocks\Mock_Update_Option
+     */
+    private static $mock_update_option_services;
+
+    /**
      * Mock for `wp_upload_dir` in the services namespace.
      *
      * @var Mocks\Mock_Wp_Upload_Dir
@@ -177,6 +185,7 @@ final class ApiHandlerAdminScheduleRefreshSiteTest extends TestCase {
         self::$mock_current_user_can         = new Mocks\Mock_Current_User_Can( __NAMESPACE__ );
         self::$mock_wp_generate_uuid4        = new Mocks\Mock_Wp_Generate_Uuid4( __NAMESPACE__ );
         self::$mock_get_option_services      = new Mocks\Mock_Get_Option( self::SERVICES_NAMESPACE );
+        self::$mock_update_option_services   = new Mocks\Mock_Update_Option( self::SERVICES_NAMESPACE );
         self::$mock_wp_upload_dir_services   = new Mocks\Mock_Wp_Upload_Dir( self::SERVICES_NAMESPACE );
         self::$mock_wp_mkdir_p_services      = new Mocks\Mock_Wp_Mkdir_P( self::SERVICES_NAMESPACE );
 
@@ -212,6 +221,7 @@ final class ApiHandlerAdminScheduleRefreshSiteTest extends TestCase {
         self::$mock_current_user_can->disable();
         self::$mock_wp_generate_uuid4->disable();
         self::$mock_get_option_services->disable();
+        self::$mock_update_option_services->disable();
         self::$mock_wp_upload_dir_services->disable();
         self::$mock_wp_mkdir_p_services->disable();
     }

--- a/test/services/classes/RefreshCounterServiceTest.php
+++ b/test/services/classes/RefreshCounterServiceTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the Refresh_Counter_Service class.
+ *
+ * @package ForceRefresh
+ */
+
+namespace JordanLeven\Plugins\ForceRefresh\Services;
+
+use JordanLeven\Plugins\ForceRefresh\Mocks;
+
+require_once __DIR__ . '/class-mocked-service-test-case.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-refresh-counter-service.php';
+
+/**
+ * Tests for Refresh_Counter_Service.
+ */
+final class RefreshCounterServiceTest extends Mocked_Service_Test_Case {
+
+    /**
+     * Mock for `get_option`.
+     *
+     * @var Mocks\Mock_Get_Option
+     */
+    private static $mock_get_option;
+
+    /**
+     * Mock for `update_option`.
+     *
+     * @var Mocks\Mock_Update_Option
+     */
+    private static $mock_update_option;
+
+    /**
+     * Initial test setup.
+     *
+     * @return void
+     */
+    public static function setUpBeforeClass(): void {
+        self::$mock_get_option    = new Mocks\Mock_Get_Option( __NAMESPACE__ );
+        self::$mock_update_option = new Mocks\Mock_Update_Option( __NAMESPACE__ );
+    }
+
+    /**
+     * Reset mocks before each test.
+     *
+     * @return void
+     */
+    public function setUp(): void {
+        self::$mock_get_option->clear_option_map();
+        self::$mock_get_option->set_return_value( 0 );
+        self::$mock_update_option->resetInvocationIndex();
+    }
+
+    /**
+     * Test teardown.
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass(): void {
+        self::disable_mocks(
+            array(
+                self::$mock_get_option,
+                self::$mock_update_option,
+            )
+        );
+    }
+
+    /**
+     * Returns zero when no site refresh count is stored.
+     */
+    public function testGetRefreshCountSiteReturnsZeroWhenNotSet(): void {
+        self::$mock_get_option->set_return_value( null );
+
+        $this->assertSame( 0, Refresh_Counter_Service::get_refresh_count_site() );
+    }
+
+    /**
+     * Returns the stored site refresh count.
+     */
+    public function testGetRefreshCountSiteReturnsStoredCount(): void {
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_site', 5 );
+
+        $this->assertSame( 5, Refresh_Counter_Service::get_refresh_count_site() );
+    }
+
+    /**
+     * Returns zero for a page with no stored count.
+     */
+    public function testGetRefreshCountPageReturnsZeroWhenNotSet(): void {
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_page', array() );
+
+        $this->assertSame( 0, Refresh_Counter_Service::get_refresh_count_page( 42 ) );
+    }
+
+    /**
+     * Returns the stored count for the given page ID.
+     */
+    public function testGetRefreshCountPageReturnsStoredCountForPage(): void {
+        self::$mock_get_option->set_option_value(
+            'force_refresh_refresh_count_page',
+            array( '42' => 3, '99' => 7 )
+        );
+
+        $this->assertSame( 3, Refresh_Counter_Service::get_refresh_count_page( 42 ) );
+        $this->assertSame( 7, Refresh_Counter_Service::get_refresh_count_page( 99 ) );
+    }
+
+    /**
+     * Increment saves the new site count via update_option.
+     */
+    public function testIncrementSiteRefreshCountSavesIncrementedValue(): void {
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_site', 4 );
+
+        Refresh_Counter_Service::increment_site_refresh_count();
+
+        $args = self::$mock_update_option->get_last_invocation_arguments();
+        $this->assertSame( 'force_refresh_refresh_count_site', $args[0] );
+        $this->assertSame( 5, $args[1] );
+    }
+
+    /**
+     * Increment page count saves the new count for the correct page ID.
+     */
+    public function testIncrementPageRefreshCountSavesIncrementedValueForPage(): void {
+        self::$mock_get_option->set_option_value(
+            'force_refresh_refresh_count_page',
+            array( '42' => 2 )
+        );
+
+        Refresh_Counter_Service::increment_page_refresh_count( 42 );
+
+        $args = self::$mock_update_option->get_last_invocation_arguments();
+        $this->assertSame( 'force_refresh_refresh_count_page', $args[0] );
+        $this->assertSame( 3, $args[1]['42'] );
+    }
+
+    /**
+     * Increment page count does not affect other pages.
+     */
+    public function testIncrementPageRefreshCountDoesNotAffectOtherPages(): void {
+        self::$mock_get_option->set_option_value(
+            'force_refresh_refresh_count_page',
+            array( '42' => 2, '99' => 10 )
+        );
+
+        Refresh_Counter_Service::increment_page_refresh_count( 42 );
+
+        $args = self::$mock_update_option->get_last_invocation_arguments();
+        $this->assertSame( 10, $args[1]['99'] );
+    }
+
+    /**
+     * Increment page count starts from zero for a new page.
+     */
+    public function testIncrementPageRefreshCountStartsFromZeroForNewPage(): void {
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_page', array() );
+
+        Refresh_Counter_Service::increment_page_refresh_count( 5 );
+
+        $args = self::$mock_update_option->get_last_invocation_arguments();
+        $this->assertSame( 1, $args[1]['5'] );
+    }
+}

--- a/test/services/classes/RefreshServiceTest.php
+++ b/test/services/classes/RefreshServiceTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests for the Refresh_Service class.
+ *
+ * @package ForceRefresh
+ */
+
+namespace JordanLeven\Plugins\ForceRefresh\Services;
+
+use JordanLeven\Plugins\ForceRefresh\Mocks;
+
+require_once __DIR__ . '/class-mocked-service-test-case.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-refresh-counter-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-version-file-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-options-storage-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-versions-storage-service.php';
+require_once __DIR__ . '/../../../includes/services/classes/class-refresh-service.php';
+
+/**
+ * Tests for Refresh_Service.
+ */
+final class RefreshServiceTest extends Mocked_Service_Test_Case {
+
+    /** @var Mocks\Mock_Get_Option */
+    private static $mock_get_option;
+
+    /** @var Mocks\Mock_Add_Option */
+    private static $mock_add_option;
+
+    /** @var Mocks\Mock_Delete_Option */
+    private static $mock_delete_option;
+
+    /** @var Mocks\Mock_Update_Option */
+    private static $mock_update_option;
+
+    /** @var Mocks\Mock_Current_Time */
+    private static $mock_current_time;
+
+    /** @var Mocks\Mock_WP_Hash */
+    private static $mock_wp_hash;
+
+    /** @var Mocks\Mock_Wp_Upload_Dir */
+    private static $mock_wp_upload_dir;
+
+    /** @var Mocks\Mock_Wp_Mkdir_P */
+    private static $mock_wp_mkdir_p;
+
+    /** @var Mocks\Mock_Wp_Json_Encode */
+    private static $mock_wp_json_encode;
+
+    /** @var string */
+    private static string $temp_dir;
+
+    public static function setUpBeforeClass(): void {
+        self::$temp_dir = sys_get_temp_dir() . '/force-refresh-refresh-service-test-' . uniqid();
+        mkdir( self::$temp_dir, 0755, true );
+
+        self::$mock_get_option     = new Mocks\Mock_Get_Option( __NAMESPACE__ );
+        self::$mock_add_option     = new Mocks\Mock_Add_Option( __NAMESPACE__ );
+        self::$mock_delete_option  = new Mocks\Mock_Delete_Option( __NAMESPACE__ );
+        self::$mock_update_option  = new Mocks\Mock_Update_Option( __NAMESPACE__ );
+        self::$mock_current_time   = new Mocks\Mock_Current_Time( __NAMESPACE__ );
+        self::$mock_wp_hash        = new Mocks\Mock_WP_Hash( __NAMESPACE__ );
+        self::$mock_wp_upload_dir  = new Mocks\Mock_Wp_Upload_Dir( __NAMESPACE__ );
+        self::$mock_wp_mkdir_p     = new Mocks\Mock_Wp_Mkdir_P( __NAMESPACE__ );
+        self::$mock_wp_json_encode = new Mocks\Mock_Wp_Json_Encode( __NAMESPACE__ );
+
+        self::$mock_wp_upload_dir->set_return_value(
+            array(
+                'basedir' => self::$temp_dir,
+                'baseurl' => 'http://example.com/wp-content/uploads',
+            )
+        );
+    }
+
+    public function setUp(): void {
+        self::$mock_get_option->set_return_value( false );
+        self::$mock_get_option->clear_option_map();
+        self::$mock_update_option->resetInvocationIndex();
+    }
+
+    public static function tearDownAfterClass(): void {
+        self::disable_mocks(
+            array(
+                self::$mock_get_option,
+                self::$mock_add_option,
+                self::$mock_delete_option,
+                self::$mock_update_option,
+                self::$mock_current_time,
+                self::$mock_wp_hash,
+                self::$mock_wp_upload_dir,
+                self::$mock_wp_mkdir_p,
+                self::$mock_wp_json_encode,
+            )
+        );
+
+        self::remove_temp_dir( self::$temp_dir );
+    }
+
+    private static function remove_temp_dir( string $path ): void {
+        if ( ! is_dir( $path ) ) {
+            return;
+        }
+
+        foreach ( array_diff( scandir( $path ), array( '.', '..' ) ) as $entry ) {
+            $full = $path . '/' . $entry;
+            is_dir( $full ) ? self::remove_temp_dir( $full ) : unlink( $full );
+        }
+
+        rmdir( $path );
+    }
+
+    /**
+     * set_new_site_version returns a non-empty version string.
+     */
+    public function testSetNewSiteVersionReturnsVersion(): void {
+        self::$mock_current_time->set_return_value( '2024-01-01 00:00:00' );
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_site', 0 );
+
+        $version = Refresh_Service::update_version_site();
+
+        $this->assertNotEmpty( $version );
+    }
+
+    /**
+     * set_new_site_version increments the site refresh counter.
+     *
+     * The counter increment is the last update_option call made by the method.
+     */
+    public function testSetNewSiteVersionIncrementsCounter(): void {
+        self::$mock_current_time->set_return_value( '2024-01-01 00:00:00' );
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_site', 3 );
+
+        Refresh_Service::update_version_site();
+
+        $args = self::$mock_update_option->get_last_invocation_arguments();
+        $this->assertSame( 'force_refresh_refresh_count_site', $args[0] );
+        $this->assertSame( 4, $args[1] );
+    }
+
+    /**
+     * set_new_page_version returns a non-empty version string.
+     */
+    public function testSetNewPageVersionReturnsVersion(): void {
+        self::$mock_current_time->set_return_value( '2024-01-01 00:00:00' );
+        self::$mock_get_option->set_option_value( 'force_refresh_page_versions', array() );
+        self::$mock_get_option->set_option_value( 'force_refresh_refresh_count_page', array() );
+
+        $version = Refresh_Service::update_version_page( 42 );
+
+        $this->assertNotEmpty( $version );
+    }
+
+    /**
+     * set_new_page_version increments the page refresh counter for the correct page.
+     *
+     * The counter increment is the last update_option call made by the method.
+     */
+    public function testSetNewPageVersionIncrementsCounter(): void {
+        self::$mock_current_time->set_return_value( '2024-01-01 00:00:00' );
+        self::$mock_get_option->set_option_value( 'force_refresh_page_versions', array() );
+        self::$mock_get_option->set_option_value(
+            'force_refresh_refresh_count_page',
+            array( '42' => 5 )
+        );
+
+        Refresh_Service::update_version_page( 42 );
+
+        $args = self::$mock_update_option->get_last_invocation_arguments();
+        $this->assertSame( 'force_refresh_refresh_count_page', $args[0] );
+        $this->assertSame( 6, $args[1]['42'] );
+    }
+}


### PR DESCRIPTION
## Description

Adds a new `Refresh_Counter_Service` that tracks how many times an admin has triggered a force refresh, split by type:

- **Site-wide refreshes** (manual and scheduled) are stored as a single integer under the `force_refresh_refresh_count_site` WordPress option.
- **Page-specific refreshes** are stored per page ID as an array under `force_refresh_refresh_count_page`.

The counter increments in all three refresh paths: site-wide refresh, page refresh, and scheduled (cron) refresh. This lays groundwork for a future metrics/dashboard feature showing refresh activity over time.

## Spec

No linked issue — this is an internal instrumentation addition.

## Validation

- [x] This PR has code changes, and our linters still pass.
- [ ] This PR effects production code, so it was browser tested (see below). _(This change is server-side only — no UI changes, no browser testing required.)_
- [x] This PR has new code, so new tests were added or updated, and they pass.

### To Validate

1. Make sure all PR Checks have passed.
1. Pull down the branch and activate the plugin on a local WordPress install.
1. Trigger a site-wide refresh from the Force Refresh admin page → run `wp option get force_refresh_refresh_count_site` and confirm the value increments.
1. Trigger a page-specific refresh for any post → run `wp option get force_refresh_refresh_count_page` and confirm the count for that page ID increments while the site count is unchanged.
1. Schedule a refresh in the near future, wait for WP Cron to fire (`/wp-cron.php?doing_wp_cron`), and confirm the site count increments again.

---

### Browser Testing

Not applicable — this PR contains no frontend or UI changes. All changes are in the PHP service layer and test suite.